### PR TITLE
fix paddingBottom calculation being a negative value

### DIFF
--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -515,7 +515,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      var winEnd = Math.min(items.length - 1, winStart + winSize - 1);
 	      var paddingTop = winStart * avgRowHeight;
-	      var paddingBottom = (items.length - winStart - winSize) * avgRowHeight;
+	      var paddingBottom = Math.max((items.length - winStart - winSize) * avgRowHeight, 0);
 	      var style = Object.assign({
 	        position: 'absolute',
 	        top: 0,

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -515,7 +515,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      var winEnd = Math.min(items.length - 1, winStart + winSize - 1);
 	      var paddingTop = winStart * avgRowHeight;
-	      var paddingBottom = (items.length - winStart - winSize) * avgRowHeight;
+	      var paddingBottom = Math.max((items.length - winStart - winSize) * avgRowHeight, 0);
 	      var style = Object.assign({
 	        position: 'absolute',
 	        top: 0,

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -337,7 +337,7 @@ class VirtualList extends React.Component {
     const { winStart, winSize, avgRowHeight } = this.state;
     const winEnd = Math.min(items.length - 1, winStart + winSize - 1);
     const paddingTop = winStart * avgRowHeight;
-    const paddingBottom = (items.length - winStart - winSize) * avgRowHeight;
+    const paddingBottom = Math.max((items.length - winStart - winSize) * avgRowHeight, 0);
     const style = Object.assign({
       position: 'absolute',
       top: 0,


### PR DESCRIPTION
In cases where we go from a long list with scrolling to a short list, the scrollbar caused by paddingBottom still exists. This is because for the new shorter list of items, the paddingBottom calculated in #render is a negative number. When the component rerenders, this is ignored as invalid and the VirtualList element retains the previous paddingBottom. 