### PR TITLE
Fix scroll to index bug

### DIFF
--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -621,8 +621,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  getItem: defaultGetItem,
 	  getItemKey: defaultGetItemKey,
 	  buffer: 4,
-	  scrollbarOffset: 0,
-	  debounce: false
+	  scrollbarOffset: 0
 	};
 
 	module.exports = VirtualList;

--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -325,9 +325,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'handleDownwardScroll',
 	    value: function handleDownwardScroll(delta, callback) {
 	      var childNodes = this.content.childNodes;
-	      var _props2 = this.props,
-	          items = _props2.items,
-	          buffer = _props2.buffer;
+	      var items = this.props.items;
 	      var _state3 = this.state,
 	          winSize = _state3.winSize,
 	          avgRowHeight = _state3.avgRowHeight;
@@ -343,7 +341,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var startScrollTop = scrollTop;
 
 	      for (var i = 0; i < childNodes.length; i++) {
-	        if (winStart < maxWinStart && childNodes[i].offsetTop + childNodes[i].offsetHeight < startScrollTop - buffer / 2 * avgRowHeight) {
+	        if (winStart < maxWinStart && childNodes[i].offsetTop + childNodes[i].offsetHeight < startScrollTop) {
 	          winStart++;
 	          scrollTop += avgRowHeight - childNodes[i].offsetHeight;
 	        } else {
@@ -362,7 +360,6 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      var node = this.node;
 	      var childNodes = this.content.childNodes;
-	      var buffer = this.props.buffer;
 	      var _state5 = this.state,
 	          winStart = _state5.winStart,
 	          scrollTop = _state5.scrollTop,
@@ -373,7 +370,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      scrollTop += delta;
 
 	      for (var i = childNodes.length - 1; i >= 0; i--) {
-	        if (winStart > 0 && childNodes[i].offsetTop - scrollTop - buffer / 2 * avgRowHeight > node.offsetHeight) {
+	        if (winStart > 0 && childNodes[i].offsetTop - scrollTop > node.offsetHeight) {
 	          winStart--;
 	          n++;
 	        } else {
@@ -509,11 +506,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    value: function render() {
 	      var _this4 = this;
 
-	      var _props3 = this.props,
-	          items = _props3.items,
-	          getItem = _props3.getItem,
-	          getItemKey = _props3.getItemKey,
-	          scrollbarOffset = _props3.scrollbarOffset;
+	      var _props2 = this.props,
+	          items = _props2.items,
+	          getItem = _props2.getItem,
+	          getItemKey = _props2.getItemKey,
+	          scrollbarOffset = _props2.scrollbarOffset;
 	      var _state9 = this.state,
 	          winStart = _state9.winStart,
 	          winSize = _state9.winSize,

--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -229,6 +229,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 	      this.notifyFirstVisibleItemIfNecessary();
+	      this.notifyLastVisibleItemIfNecessary();
 
 	      if (childNodes.length < winSize) {
 	        this.sampleRowHeights();
@@ -304,6 +305,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	      }
 	    }
 	  }, {
+	    key: 'notifyLastVisibleItemIfNecessary',
+	    value: function notifyLastVisibleItemIfNecessary() {
+	      if (!this.props.onLastVisibleItemChange) {
+	        return;
+	      }
+
+	      var idx = this.findLastVisibleItemIndex();
+
+	      if (this._lastIndex !== idx) {
+	        this.props.onLastVisibleItemChange(this.props.items[idx], idx);
+	        this._lastIndex = idx;
+	      }
+	    }
+	  }, {
 	    key: 'findFirstVisibleItemIndex',
 	    value: function findFirstVisibleItemIndex() {
 	      var childNodes = this.content.childNodes;
@@ -322,18 +337,37 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return undefined;
 	    }
 	  }, {
+	    key: 'findLastVisibleItemIndex',
+	    value: function findLastVisibleItemIndex() {
+	      var childNodes = this.content.childNodes;
+	      var items = this.props.items;
+	      var _state3 = this.state,
+	          winStart = _state3.winStart,
+	          scrollTop = _state3.scrollTop,
+	          viewportHeight = _state3.viewportHeight;
+
+
+	      for (var i = childNodes.length - 1; i >= 0; i--) {
+	        if (childNodes[i].offsetTop < scrollTop + viewportHeight) {
+	          return winStart + i;
+	        }
+	      }
+
+	      return undefined;
+	    }
+	  }, {
 	    key: 'handleDownwardScroll',
 	    value: function handleDownwardScroll(delta, callback) {
 	      var childNodes = this.content.childNodes;
 	      var items = this.props.items;
-	      var _state3 = this.state,
-	          winSize = _state3.winSize,
-	          avgRowHeight = _state3.avgRowHeight;
+	      var _state4 = this.state,
+	          winSize = _state4.winSize,
+	          avgRowHeight = _state4.avgRowHeight;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
-	      var _state4 = this.state,
-	          winStart = _state4.winStart,
-	          scrollTop = _state4.scrollTop;
+	      var _state5 = this.state,
+	          winStart = _state5.winStart,
+	          scrollTop = _state5.scrollTop;
 
 
 	      scrollTop += delta;
@@ -360,10 +394,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      var node = this.node;
 	      var childNodes = this.content.childNodes;
-	      var _state5 = this.state,
-	          winStart = _state5.winStart,
-	          scrollTop = _state5.scrollTop,
-	          avgRowHeight = _state5.avgRowHeight;
+	      var _state6 = this.state,
+	          winStart = _state6.winStart,
+	          scrollTop = _state6.scrollTop,
+	          avgRowHeight = _state6.avgRowHeight;
 
 	      var n = 0;
 
@@ -397,9 +431,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'handleLongScroll',
 	    value: function handleLongScroll(delta, callback) {
 	      var items = this.props.items;
-	      var _state6 = this.state,
-	          winSize = _state6.winSize,
-	          avgRowHeight = _state6.avgRowHeight;
+	      var _state7 = this.state,
+	          winSize = _state7.winSize,
+	          avgRowHeight = _state7.avgRowHeight;
 	      var scrollTop = this.state.scrollTop;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
@@ -429,9 +463,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'scrollToIndex',
 	    value: function scrollToIndex(index, callback) {
 	      var items = this.props.items;
-	      var _state7 = this.state,
-	          winSize = _state7.winSize,
-	          avgRowHeight = _state7.avgRowHeight;
+	      var _state8 = this.state,
+	          winSize = _state8.winSize,
+	          avgRowHeight = _state8.avgRowHeight;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
 	      var winStart = Math.min(maxWinStart, index);
@@ -467,9 +501,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'itemsMutated',
 	    value: function itemsMutated(callback) {
 	      var items = this.props.items;
-	      var _state8 = this.state,
-	          winStart = _state8.winStart,
-	          winSize = _state8.winSize;
+	      var _state9 = this.state,
+	          winStart = _state9.winStart,
+	          winSize = _state9.winSize;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
 
@@ -512,10 +546,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	          getItem = _props2.getItem,
 	          getItemKey = _props2.getItemKey,
 	          scrollbarOffset = _props2.scrollbarOffset;
-	      var _state9 = this.state,
-	          winStart = _state9.winStart,
-	          winSize = _state9.winSize,
-	          avgRowHeight = _state9.avgRowHeight;
+	      var _state10 = this.state,
+	          winStart = _state10.winStart,
+	          winSize = _state10.winSize,
+	          avgRowHeight = _state10.avgRowHeight;
 
 	      var winEnd = Math.min(items.length - 1, winStart + winSize - 1);
 	      var paddingTop = winStart * avgRowHeight;

--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -443,8 +443,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return this;
 	    }
 	  }, {
-	    key: 'scrollToIndex',
-	    value: function scrollToIndex(index, callback) {
+	    key: '_scrollToIndex',
+	    value: function _scrollToIndex(index, callback) {
 	      var items = this.props.items;
 	      var _state9 = this.state,
 	          winSize = _state9.winSize,
@@ -455,6 +455,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var scrollTop = winStart * avgRowHeight;
 
 	      this.setState({ winStart: winStart, scrollTop: scrollTop }, callback);
+	    }
+	  }, {
+	    key: 'scrollToIndex',
+	    value: function scrollToIndex(index, callback) {
+	      var _this4 = this;
+
+	      if (this.state.avgRowHeight === 1) {
+	        // The average row height is still the initial value, which means that we
+	        // haven't sampled the row heights yet, which we need in order to properly
+	        // scroll to the right position. So we need to delay the scroll logic
+	        // until after the list has had a chance to sample the row heights.
+	        this.setState({}, function () {
+	          _this4._scrollToIndex(index, callback);
+	        });
+	      } else {
+	        this._scrollToIndex(index, callback);
+	      }
 	    }
 	  }, {
 	    key: 'scrollToItem',
@@ -514,7 +531,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }, {
 	    key: 'render',
 	    value: function render() {
-	      var _this4 = this;
+	      var _this5 = this;
 
 	      var _props2 = this.props,
 	          items = _props2.items,
@@ -561,7 +578,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        'div',
 	        {
 	          ref: function ref(node) {
-	            _this4.node = node;
+	            _this5.node = node;
 	          },
 	          className: 'VirtualList',
 	          tabIndex: '-1',
@@ -571,7 +588,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	          'div',
 	          {
 	            ref: function ref(content) {
-	              _this4.content = content;
+	              _this5.content = content;
 	            },
 	            className: 'VirtualList-content',
 	            style: contentStyle },

--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -161,12 +161,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  // Internal: After the component is mounted we do the following:
 	  //
-	  // 1. Start a timer to periodically check for resizes of the container. When the container is
-	  //    resized we have to adjust the display window to ensure that we are rendering enough items
-	  //    to fill the viewport.
-	  // 2. Calculate the initial viewport height and display window size by triggering the resize
-	  //    handler.
-	  // 3. Sample the just rendered row heights to get an average row height to use while handling
+	  // 1. Start a requestAnimationFrame loop that checks for resize and scroll updates. When the
+	  //    container is resized we have to adjust the display window to ensure that we are rendering
+	  //    enough items to fill the viewport. When the container is scrolled we need to adjust the
+	  //    rendered window and item positions.
+	  // 2. Sample the just rendered row heights to get an average row height to use while handling
 	  //    scroll events.
 
 
@@ -212,6 +211,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	    value: function componentWillUnmount() {
 	      cancelAnimationFrame(this._raf);
 	    }
+
+	    // Internal: This method gets called on each animation frame. It checks for the following:
+	    //
+	    // 1. Viewport height changes. When the viewport height has changed, we need to adjust the render
+	    //    window to ensure that we have enough items to fill it.
+	    // 2. Sroll changes. If the container has been scrolled since the last time we renedered we may
+	    //    need to adjust the render window.
+
 	  }, {
 	    key: 'animationLoop',
 	    value: function animationLoop() {

--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -296,16 +296,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	        return;
 	      }
 
-	      var first = this.findFirstVisibleItem();
+	      var idx = this.findFirstVisibleItemIndex();
 
-	      if (this._first !== first) {
-	        this.props.onFirstVisibleItemChange(first);
-	        this._first = first;
+	      if (this._firstIndex !== idx) {
+	        this.props.onFirstVisibleItemChange(this.props.items[idx], idx);
+	        this._firstIndex = idx;
 	      }
 	    }
 	  }, {
-	    key: 'findFirstVisibleItem',
-	    value: function findFirstVisibleItem() {
+	    key: 'findFirstVisibleItemIndex',
+	    value: function findFirstVisibleItemIndex() {
 	      var childNodes = this.content.childNodes;
 	      var items = this.props.items;
 	      var _state2 = this.state,
@@ -315,7 +315,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      for (var i = 0; i < childNodes.length; i++) {
 	        if (childNodes[i].offsetTop + childNodes[i].offsetHeight >= scrollTop) {
-	          return items[winStart + i];
+	          return winStart + i;
 	        }
 	      }
 
@@ -405,7 +405,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var maxWinStart = Math.max(0, items.length - winSize);
 	      scrollTop += delta;
 	      this.setState({
-	        winStart: Math.min(maxWinStart, Math.floor(scrollTop / avgRowHeight)), scrollTop: scrollTop
+	        winStart: Math.min(maxWinStart, Math.floor(scrollTop / avgRowHeight)),
+	        scrollTop: scrollTop
 	      }, callback);
 	    }
 	  }, {
@@ -528,26 +529,43 @@ return /******/ (function(modules) { // webpackBootstrap
 	        overflowY: 'auto',
 	        overflowX: scrollbarOffset ? 'hidden' : undefined
 	      }, this.props.style);
-	      var contentStyle = { paddingTop: paddingTop, paddingBottom: paddingBottom, marginRight: -scrollbarOffset };
+	      var contentStyle = {
+	        paddingTop: paddingTop,
+	        paddingBottom: paddingBottom,
+	        marginRight: -scrollbarOffset
+	      };
 	      var itemView = _react2.default.Children.only(this.props.children);
 	      var itemNodes = [];
 	      var item = void 0;
 
 	      for (var i = winStart; i <= winEnd; i++) {
 	        item = getItem(items, i);
-	        itemNodes.push(_react2.default.createElement(Item, { key: getItemKey(item, i), itemIndex: i, itemView: itemView, item: item }));
+	        itemNodes.push(_react2.default.createElement(Item, {
+	          key: getItemKey(item, i),
+	          itemIndex: i,
+	          itemView: itemView,
+	          item: item
+	        }));
 	      }
 
 	      return _react2.default.createElement(
 	        'div',
-	        { ref: function ref(node) {
+	        {
+	          ref: function ref(node) {
 	            _this4.node = node;
-	          }, className: 'VirtualList', tabIndex: '-1', style: style, onScroll: this.onScroll },
+	          },
+	          className: 'VirtualList',
+	          tabIndex: '-1',
+	          style: style,
+	          onScroll: this.onScroll },
 	        _react2.default.createElement(
 	          'div',
-	          { ref: function ref(content) {
+	          {
+	            ref: function ref(content) {
 	              _this4.content = content;
-	            }, className: 'VirtualList-content', style: contentStyle },
+	            },
+	            className: 'VirtualList-content',
+	            style: contentStyle },
 	          itemNodes
 	        )
 	      );

--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -155,8 +155,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      scrollTop: 0
 	    };
 
-	    _this2.checkForResize = _this2.checkForResize.bind(_this2);
-	    _this2.handleScroll = _this2.handleScroll.bind(_this2);
+	    _this2.animationLoop = _this2.animationLoop.bind(_this2);
 	    return _this2;
 	  }
 
@@ -174,10 +173,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  _createClass(VirtualList, [{
 	    key: 'componentDidMount',
 	    value: function componentDidMount() {
-	      this._resizeTimer = setInterval(this.checkForResize, this.props.resizeInterval);
-	      this.handleResize();
+	      this.animationLoop();
 	      this.sampleRowHeights();
-	      this.handleScroll();
 	    }
 
 	    // Internal: After the component is updated we do the following:
@@ -213,19 +210,26 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }, {
 	    key: 'componentWillUnmount',
 	    value: function componentWillUnmount() {
-	      clearInterval(this._resizeTimer);
-	      cancelAnimationFrame(this._handleScrollRAF);
+	      cancelAnimationFrame(this._raf);
 	    }
 	  }, {
-	    key: 'checkForResize',
-	    value: function checkForResize() {
-	      var clientHeight = this.node.clientHeight;
-	      var viewportHeight = this.state.viewportHeight;
+	    key: 'animationLoop',
+	    value: function animationLoop() {
+	      var node = this.node;
+	      var _state2 = this.state,
+	          scrollTop = _state2.scrollTop,
+	          viewportHeight = _state2.viewportHeight;
 
 
-	      if (clientHeight !== viewportHeight) {
+	      if (node.clientHeight !== viewportHeight) {
 	        this.handleResize();
 	      }
+
+	      if (node.scrollTop !== scrollTop) {
+	        this.scroll(node.scrollTop - scrollTop);
+	      }
+
+	      this._raf = requestAnimationFrame(this.animationLoop);
 	    }
 
 	    // Internal: When the container node has been resized we need to adjust the internal
@@ -295,9 +299,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    value: function findFirstVisibleItemIndex() {
 	      var childNodes = this.content.childNodes;
 	      var items = this.props.items;
-	      var _state2 = this.state,
-	          winStart = _state2.winStart,
-	          scrollTop = _state2.scrollTop;
+	      var _state3 = this.state,
+	          winStart = _state3.winStart,
+	          scrollTop = _state3.scrollTop;
 
 
 	      for (var i = 0; i < childNodes.length; i++) {
@@ -313,10 +317,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    value: function findLastVisibleItemIndex() {
 	      var childNodes = this.content.childNodes;
 	      var items = this.props.items;
-	      var _state3 = this.state,
-	          winStart = _state3.winStart,
-	          scrollTop = _state3.scrollTop,
-	          viewportHeight = _state3.viewportHeight;
+	      var _state4 = this.state,
+	          winStart = _state4.winStart,
+	          scrollTop = _state4.scrollTop,
+	          viewportHeight = _state4.viewportHeight;
 
 
 	      for (var i = childNodes.length - 1; i >= 0; i--) {
@@ -332,14 +336,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	    value: function handleDownwardScroll(delta, callback) {
 	      var childNodes = this.content.childNodes;
 	      var items = this.props.items;
-	      var _state4 = this.state,
-	          winSize = _state4.winSize,
-	          avgRowHeight = _state4.avgRowHeight;
+	      var _state5 = this.state,
+	          winSize = _state5.winSize,
+	          avgRowHeight = _state5.avgRowHeight;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
-	      var _state5 = this.state,
-	          winStart = _state5.winStart,
-	          scrollTop = _state5.scrollTop;
+	      var _state6 = this.state,
+	          winStart = _state6.winStart,
+	          scrollTop = _state6.scrollTop;
 
 
 	      scrollTop += delta;
@@ -366,10 +370,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      var node = this.node;
 	      var childNodes = this.content.childNodes;
-	      var _state6 = this.state,
-	          winStart = _state6.winStart,
-	          scrollTop = _state6.scrollTop,
-	          avgRowHeight = _state6.avgRowHeight;
+	      var _state7 = this.state,
+	          winStart = _state7.winStart,
+	          scrollTop = _state7.scrollTop,
+	          avgRowHeight = _state7.avgRowHeight;
 
 	      var n = 0;
 
@@ -403,9 +407,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'handleLongScroll',
 	    value: function handleLongScroll(delta, callback) {
 	      var items = this.props.items;
-	      var _state7 = this.state,
-	          winSize = _state7.winSize,
-	          avgRowHeight = _state7.avgRowHeight;
+	      var _state8 = this.state,
+	          winSize = _state8.winSize,
+	          avgRowHeight = _state8.avgRowHeight;
 	      var scrollTop = this.state.scrollTop;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
@@ -435,9 +439,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'scrollToIndex',
 	    value: function scrollToIndex(index, callback) {
 	      var items = this.props.items;
-	      var _state8 = this.state,
-	          winSize = _state8.winSize,
-	          avgRowHeight = _state8.avgRowHeight;
+	      var _state9 = this.state,
+	          winSize = _state9.winSize,
+	          avgRowHeight = _state9.avgRowHeight;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
 	      var winStart = Math.min(maxWinStart, index);
@@ -473,9 +477,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'itemsMutated',
 	    value: function itemsMutated(callback) {
 	      var items = this.props.items;
-	      var _state9 = this.state,
-	          winStart = _state9.winStart,
-	          winSize = _state9.winSize;
+	      var _state10 = this.state,
+	          winStart = _state10.winStart,
+	          winSize = _state10.winSize;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
 
@@ -510,10 +514,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	          getItem = _props2.getItem,
 	          getItemKey = _props2.getItemKey,
 	          scrollbarOffset = _props2.scrollbarOffset;
-	      var _state10 = this.state,
-	          winStart = _state10.winStart,
-	          winSize = _state10.winSize,
-	          avgRowHeight = _state10.avgRowHeight;
+	      var _state11 = this.state,
+	          winStart = _state11.winStart,
+	          winSize = _state11.winSize,
+	          avgRowHeight = _state11.avgRowHeight;
 
 	      var winEnd = Math.min(items.length - 1, winStart + winSize - 1);
 	      var paddingTop = winStart * avgRowHeight;
@@ -602,11 +606,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  // Offset the scrollbar by the number of pixels specified. The default is 0.
 	  scrollbarOffset: _propTypes2.default.number,
 
-	  // Specify how often to check for a resize of the component in milliseconds. The virtual list
-	  // must recompute its window size when the component is resized because it may no longer be
-	  // large enough to fill the viewport. Default is 1000ms.
-	  resizeInterval: _propTypes2.default.number,
-
 	  // Style object applied to the container.
 	  style: _propTypes2.default.object
 	};
@@ -616,7 +615,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  getItemKey: defaultGetItemKey,
 	  buffer: 4,
 	  scrollbarOffset: 0,
-	  resizeInterval: 1000,
 	  debounce: false
 	};
 

--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -102,35 +102,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return Item;
 	}(_react2.default.PureComponent);
 
-	var debounce = function debounce(func, wait) {
-	  var timeout = void 0,
-	      result = void 0;
-	  var later = function later(context, args) {
-	    timeout = null;
-	    if (args) result = func.apply(context, args);
-	  };
-	  var delay = function delay(func, wait) {
-	    for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
-	      args[_key - 2] = arguments[_key];
-	    }
-
-	    return setTimeout(function () {
-	      return func.apply(null, args);
-	    }, wait);
-	  };
-	  var debounced = function debounced() {
-	    for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
-	      args[_key2] = arguments[_key2];
-	    }
-
-	    if (timeout) clearTimeout(timeout);
-	    timeout = delay(later, wait, undefined, args);
-	    return result;
-	  };
-
-	  return debounced;
-	};
-
 	function defaultGetItem(items, index) {
 	  return items[index];
 	}
@@ -184,9 +155,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      scrollTop: 0
 	    };
 
-	    _this2.onScroll = _this2.onScroll.bind(_this2);
-	    _this2.debouncedOnScroll = props.debounce ? debounce(_this2.debouncedOnScroll.bind(_this2), 30) : _this2.debouncedOnScroll;
 	    _this2.checkForResize = _this2.checkForResize.bind(_this2);
+	    _this2.handleScroll = _this2.handleScroll.bind(_this2);
 	    return _this2;
 	  }
 
@@ -207,6 +177,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      this._resizeTimer = setInterval(this.checkForResize, this.props.resizeInterval);
 	      this.handleResize();
 	      this.sampleRowHeights();
+	      this.handleScroll();
 	    }
 
 	    // Internal: After the component is updated we do the following:
@@ -243,6 +214,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'componentWillUnmount',
 	    value: function componentWillUnmount() {
 	      clearInterval(this._resizeTimer);
+	      cancelAnimationFrame(this._handleScrollRAF);
 	    }
 	  }, {
 	    key: 'checkForResize',
@@ -516,17 +488,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return this;
 	    }
 	  }, {
-	    key: 'onScroll',
-	    value: function onScroll(e) {
-	      e.persist();
-	      if (e.target.scrollTop === this.state.scrollTop) {
-	        this.props.onScroll && this.props.onScroll(e);
-	      }
-	      this.debouncedOnScroll(e);
-	    }
-	  }, {
-	    key: 'debouncedOnScroll',
-	    value: function debouncedOnScroll(e) {
+	    key: 'handleScroll',
+	    value: function handleScroll() {
 	      var node = this.node;
 	      var scrollTop = this.state.scrollTop;
 
@@ -534,7 +497,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      if (node.scrollTop !== scrollTop) {
 	        this.scroll(node.scrollTop - scrollTop);
 	      }
-	      this.props.onScroll && this.props.onScroll(e);
+
+	      this._handleScrollRAF = requestAnimationFrame(this.handleScroll);
 	    }
 	  }, {
 	    key: 'render',
@@ -591,7 +555,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	          className: 'VirtualList',
 	          tabIndex: '-1',
 	          style: style,
-	          onScroll: this.onScroll },
+	          onScroll: this.props.onScroll },
 	        _react2.default.createElement(
 	          'div',
 	          {
@@ -644,10 +608,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  resizeInterval: _propTypes2.default.number,
 
 	  // Style object applied to the container.
-	  style: _propTypes2.default.object,
-
-	  // Specify whether to debounce onScroll handler
-	  debounce: _propTypes2.default.bool
+	  style: _propTypes2.default.object
 	};
 
 	VirtualList.defaultProps = {

--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -340,8 +340,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      scrollTop += delta;
 
+	      var startScrollTop = scrollTop;
+
 	      for (var i = 0; i < childNodes.length; i++) {
-	        if (winStart < maxWinStart && childNodes[i].offsetTop + childNodes[i].offsetHeight < scrollTop - buffer / 2 * avgRowHeight) {
+	        if (winStart < maxWinStart && childNodes[i].offsetTop + childNodes[i].offsetHeight < startScrollTop - buffer / 2 * avgRowHeight) {
 	          winStart++;
 	          scrollTop += avgRowHeight - childNodes[i].offsetHeight;
 	        } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,13 +4,19 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "Base64": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg=",
+      "dev": true
+    },
     "accepts": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
       "integrity": "sha1-1xyW99QdD+2iw4zRToonwEFY30o=",
       "dev": true,
       "requires": {
-        "mime-types": "2.0.14",
+        "mime-types": "~2.0.4",
         "negotiator": "0.4.9"
       },
       "dependencies": {
@@ -26,7 +32,7 @@
           "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
           "dev": true,
           "requires": {
-            "mime-db": "1.12.0"
+            "mime-db": "~1.12.0"
           }
         }
       }
@@ -43,9 +49,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -72,8 +78,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "arr-diff": {
@@ -82,7 +88,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -142,9 +148,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
@@ -153,27 +159,27 @@
       "integrity": "sha1-KD8iErsD1OXNdJi5iG779vwuI44=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.0",
-        "debug": "2.6.8",
-        "json5": "0.4.0",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-exists": "1.0.0",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
-        "shebang-regex": "1.0.0",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.8.0",
+        "babel-generator": "^6.9.0",
+        "babel-helpers": "^6.8.0",
+        "babel-messages": "^6.8.0",
+        "babel-register": "^6.9.0",
+        "babel-runtime": "^6.9.1",
+        "babel-template": "^6.9.0",
+        "babel-traverse": "^6.10.4",
+        "babel-types": "^6.9.1",
+        "babylon": "^6.7.0",
+        "convert-source-map": "^1.1.0",
+        "debug": "^2.1.1",
+        "json5": "^0.4.0",
+        "lodash": "^4.2.0",
+        "minimatch": "^3.0.2",
+        "path-exists": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "private": "^0.1.6",
+        "shebang-regex": "^1.0.0",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.0"
       }
     },
     "babel-generator": {
@@ -182,14 +188,14 @@
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.6",
+        "trim-right": "^1.0.1"
       }
     },
     "babel-helper-builder-react-jsx": {
@@ -198,9 +204,9 @@
       "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "esutils": "2.0.2"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "esutils": "^2.0.2"
       }
     },
     "babel-helper-call-delegate": {
@@ -209,10 +215,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -221,10 +227,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-function-name": {
@@ -233,11 +239,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -246,8 +252,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -256,8 +262,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -266,8 +272,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -276,9 +282,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-replace-supers": {
@@ -287,12 +293,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -301,8 +307,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-loader": {
@@ -311,9 +317,9 @@
       "integrity": "sha1-qnCv+N3CI6WVLoOaQ6bDpMi/oek=",
       "dev": true,
       "requires": {
-        "loader-utils": "0.2.17",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
+        "loader-utils": "^0.2.11",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.0.1"
       }
     },
     "babel-messages": {
@@ -322,7 +328,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -331,7 +337,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-syntax-flow": {
@@ -352,7 +358,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -361,7 +367,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -370,11 +376,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -383,15 +389,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -400,8 +406,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -410,7 +416,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -419,8 +425,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -429,7 +435,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -438,9 +444,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -449,7 +455,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -458,10 +464,10 @@
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -470,8 +476,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -480,12 +486,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -494,8 +500,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -504,7 +510,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -513,9 +519,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -524,7 +530,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -533,7 +539,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -542,9 +548,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -553,8 +559,8 @@
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-flow": "^6.18.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-display-name": {
@@ -563,7 +569,7 @@
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx": {
@@ -572,9 +578,9 @@
       "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-react-jsx": "6.26.0",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-react-jsx": "^6.24.1",
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx-self": {
@@ -583,8 +589,8 @@
       "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx-source": {
@@ -593,8 +599,8 @@
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -603,7 +609,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -612,8 +618,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-preset-es2015": {
@@ -622,27 +628,27 @@
       "integrity": "sha1-leRxasRIHfswmZy1wRGBThraD0E=",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0"
+        "babel-plugin-check-es2015-constants": "^6.3.13",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.3.13",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.3.13",
+        "babel-plugin-transform-es2015-block-scoping": "^6.9.0",
+        "babel-plugin-transform-es2015-classes": "^6.9.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.3.13",
+        "babel-plugin-transform-es2015-destructuring": "^6.9.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.6.0",
+        "babel-plugin-transform-es2015-for-of": "^6.6.0",
+        "babel-plugin-transform-es2015-function-name": "^6.9.0",
+        "babel-plugin-transform-es2015-literals": "^6.3.13",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.6.0",
+        "babel-plugin-transform-es2015-object-super": "^6.3.13",
+        "babel-plugin-transform-es2015-parameters": "^6.9.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.3.13",
+        "babel-plugin-transform-es2015-spread": "^6.3.13",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.3.13",
+        "babel-plugin-transform-es2015-template-literals": "^6.6.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.6.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.3.13",
+        "babel-plugin-transform-regenerator": "^6.9.0"
       }
     },
     "babel-preset-react": {
@@ -651,13 +657,13 @@
       "integrity": "sha1-mKwr08G3bzBirgglgOreFUoZtZA=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-plugin-transform-flow-strip-types": "6.22.0",
-        "babel-plugin-transform-react-display-name": "6.25.0",
-        "babel-plugin-transform-react-jsx": "6.24.1",
-        "babel-plugin-transform-react-jsx-self": "6.22.0",
-        "babel-plugin-transform-react-jsx-source": "6.22.0"
+        "babel-plugin-syntax-flow": "^6.3.13",
+        "babel-plugin-syntax-jsx": "^6.3.13",
+        "babel-plugin-transform-flow-strip-types": "^6.3.13",
+        "babel-plugin-transform-react-display-name": "^6.3.13",
+        "babel-plugin-transform-react-jsx": "^6.3.13",
+        "babel-plugin-transform-react-jsx-self": "^6.11.0",
+        "babel-plugin-transform-react-jsx-source": "^6.3.13"
       }
     },
     "babel-register": {
@@ -666,13 +672,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.0",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.16"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       },
       "dependencies": {
         "babel-core": {
@@ -681,25 +687,25 @@
           "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.0",
-            "babel-helpers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "convert-source-map": "1.5.0",
-            "debug": "2.6.8",
-            "json5": "0.5.1",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.7",
-            "slash": "1.0.0",
-            "source-map": "0.5.7"
+            "babel-code-frame": "^6.26.0",
+            "babel-generator": "^6.26.0",
+            "babel-helpers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "convert-source-map": "^1.5.0",
+            "debug": "^2.6.8",
+            "json5": "^0.5.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4",
+            "path-is-absolute": "^1.0.1",
+            "private": "^0.1.7",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.6"
           }
         },
         "json5": {
@@ -716,8 +722,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.0",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -726,11 +732,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -739,15 +745,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.8",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -756,10 +762,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -778,12 +784,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "Base64": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg=",
       "dev": true
     },
     "base64-arraybuffer": {
@@ -850,15 +850,15 @@
       "dev": true,
       "requires": {
         "bytes": "2.4.0",
-        "content-type": "1.0.2",
+        "content-type": "~1.0.2",
         "debug": "2.6.7",
-        "depd": "1.1.1",
-        "http-errors": "1.6.2",
+        "depd": "~1.1.0",
+        "http-errors": "~1.6.1",
         "iconv-lite": "0.4.15",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.4.0",
-        "raw-body": "2.2.0",
-        "type-is": "1.6.15"
+        "raw-body": "~2.2.0",
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "debug": {
@@ -878,7 +878,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -888,9 +888,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "browserify-zlib": {
@@ -899,7 +899,7 @@
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
-        "pako": "0.2.9"
+        "pako": "~0.2.0"
       }
     },
     "buffer": {
@@ -908,9 +908,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.1",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "bytes": {
@@ -937,8 +937,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -947,11 +947,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "chokidar": {
@@ -960,15 +960,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.2",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "cliui": {
@@ -977,8 +977,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -1008,7 +1008,7 @@
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.5.0"
       }
     },
     "component-bind": {
@@ -1043,7 +1043,7 @@
       "requires": {
         "debug": "2.6.8",
         "finalhandler": "1.0.4",
-        "parseurl": "1.3.1",
+        "parseurl": "~1.3.1",
         "utils-merge": "1.0.0"
       }
     },
@@ -1053,7 +1053,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "constants-browserify": {
@@ -1085,17 +1085,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "create-react-class": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
-      "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
-      "dev": true,
-      "requires": {
-        "fbjs": "0.8.14",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
     },
     "crypto-browserify": {
       "version": "3.2.8",
@@ -1147,7 +1136,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "di": {
@@ -1162,10 +1151,10 @@
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
       "requires": {
-        "custom-event": "1.0.1",
-        "ent": "2.2.0",
-        "extend": "3.0.1",
-        "void-elements": "2.0.1"
+        "custom-event": "~1.0.0",
+        "ent": "~2.2.0",
+        "extend": "^3.0.0",
+        "void-elements": "^2.0.0"
       }
     },
     "domain-browser": {
@@ -1198,7 +1187,7 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.15"
+        "iconv-lite": "~0.4.13"
       }
     },
     "engine.io": {
@@ -1305,9 +1294,9 @@
       "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.2.0",
-        "tapable": "0.1.10"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.2.0",
+        "tapable": "^0.1.8"
       },
       "dependencies": {
         "memory-fs": {
@@ -1330,7 +1319,7 @@
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "dev": true,
       "requires": {
-        "prr": "0.0.0"
+        "prr": "~0.0.0"
       }
     },
     "escape-html": {
@@ -1375,9 +1364,9 @@
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
       "requires": {
-        "array-slice": "0.2.3",
-        "array-unique": "0.2.1",
-        "braces": "0.1.5"
+        "array-slice": "^0.2.3",
+        "array-unique": "^0.2.1",
+        "braces": "^0.1.2"
       },
       "dependencies": {
         "braces": {
@@ -1386,7 +1375,7 @@
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
           "dev": true,
           "requires": {
-            "expand-range": "0.1.1"
+            "expand-range": "^0.1.0"
           }
         },
         "expand-range": {
@@ -1395,8 +1384,8 @@
           "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
           "dev": true,
           "requires": {
-            "is-number": "0.1.1",
-            "repeat-string": "0.2.2"
+            "is-number": "^0.1.1",
+            "repeat-string": "^0.2.2"
           }
         },
         "is-number": {
@@ -1419,7 +1408,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -1428,7 +1417,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "extend": {
@@ -1443,7 +1432,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "fbjs": {
@@ -1452,13 +1441,13 @@
       "integrity": "sha1-0dviviVMNakeCfMfnNUKQLKg7Rw=",
       "dev": true,
       "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.14"
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.9"
       },
       "dependencies": {
         "core-js": {
@@ -1481,11 +1470,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "finalhandler": {
@@ -1495,12 +1484,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.8",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       }
     },
     "for-in": {
@@ -1515,7 +1504,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "fs-access": {
@@ -1524,7 +1513,7 @@
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
-        "null-check": "1.0.0"
+        "null-check": "^1.0.0"
       }
     },
     "fs.realpath": {
@@ -1540,8 +1529,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.6.36"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.36"
       },
       "dependencies": {
         "abbrev": {
@@ -1556,14 +1545,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -1577,8 +1567,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "asn1": {
@@ -1614,7 +1604,8 @@
         "balanced-match": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -1622,38 +1613,42 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "~2.0.0"
           }
         },
         "boom": {
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "brace-expansion": {
           "version": "1.1.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -1670,30 +1665,35 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
@@ -1701,7 +1701,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "dashdash": {
@@ -1710,7 +1710,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -1739,7 +1739,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -1753,7 +1754,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "extend": {
@@ -1765,7 +1766,8 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -1779,25 +1781,27 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "fstream-ignore": {
@@ -1806,9 +1810,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
           }
         },
         "gauge": {
@@ -1817,14 +1821,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "getpass": {
@@ -1833,7 +1837,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -1848,19 +1852,21 @@
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -1874,8 +1880,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "has-unicode": {
@@ -1890,16 +1896,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -1907,24 +1914,26 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.4",
@@ -1936,8 +1945,9 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -1949,7 +1959,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -1963,7 +1974,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "jsbn": {
@@ -1984,7 +1995,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -2022,33 +2033,38 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2065,15 +2081,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "request": "^2.81.0",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^2.2.1",
+            "tar-pack": "^3.4.0"
           }
         },
         "nopt": {
@@ -2082,8 +2098,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npmlog": {
@@ -2092,16 +2108,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -2119,8 +2136,9 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -2141,14 +2159,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "performance-now": {
           "version": "0.2.0",
@@ -2159,7 +2178,8 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -2179,10 +2199,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2197,14 +2217,15 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "request": {
@@ -2213,42 +2234,44 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -2274,7 +2297,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "sshpk": {
@@ -2283,15 +2306,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -2302,22 +2325,24 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
           }
         },
         "stringstream": {
@@ -2330,8 +2355,9 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -2344,10 +2370,11 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "tar-pack": {
@@ -2356,14 +2383,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "debug": "^2.2.0",
+            "fstream": "^1.0.10",
+            "fstream-ignore": "^1.0.5",
+            "once": "^1.3.3",
+            "readable-stream": "^2.1.4",
+            "rimraf": "^2.5.1",
+            "tar": "^2.2.1",
+            "uid-number": "^0.0.6"
           }
         },
         "tough-cookie": {
@@ -2372,7 +2399,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -2381,7 +2408,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -2399,7 +2426,8 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -2422,13 +2450,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2438,12 +2467,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -2452,8 +2481,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -2462,7 +2491,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "globals": {
@@ -2483,7 +2512,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-binary": {
@@ -2521,8 +2550,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "http-browserify": {
@@ -2531,8 +2560,8 @@
       "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
       "dev": true,
       "requires": {
-        "Base64": "0.2.1",
-        "inherits": "2.0.3"
+        "Base64": "~0.2.0",
+        "inherits": "~2.0.1"
       }
     },
     "http-errors": {
@@ -2544,7 +2573,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": ">= 1.3.1 < 2"
       }
     },
     "http-proxy": {
@@ -2553,8 +2582,8 @@
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
       }
     },
     "https-browserify": {
@@ -2587,8 +2616,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -2609,7 +2638,7 @@
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "is-binary-path": {
@@ -2618,7 +2647,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.10.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -2639,7 +2668,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -2660,7 +2689,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -2669,7 +2698,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-number": {
@@ -2678,7 +2707,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-posix-bracket": {
@@ -2732,8 +2761,8 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "dev": true,
       "requires": {
-        "node-fetch": "1.7.2",
-        "whatwg-fetch": "2.0.3"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "jasmine-core": {
@@ -2772,31 +2801,31 @@
       "integrity": "sha1-bcqJ7CX0dT8SD4NMiTmAmAQP1j4=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.0",
-        "body-parser": "1.17.2",
-        "chokidar": "1.7.0",
-        "colors": "1.1.2",
-        "combine-lists": "1.0.1",
-        "connect": "3.6.3",
-        "core-js": "2.5.0",
-        "di": "0.0.1",
-        "dom-serialize": "2.2.1",
-        "expand-braces": "0.1.2",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "http-proxy": "1.16.2",
-        "isbinaryfile": "3.0.2",
-        "lodash": "3.10.1",
-        "log4js": "0.6.38",
-        "mime": "1.4.0",
-        "minimatch": "3.0.4",
-        "optimist": "0.6.1",
-        "qjobs": "1.1.5",
-        "rimraf": "2.6.1",
+        "bluebird": "^3.3.0",
+        "body-parser": "^1.12.4",
+        "chokidar": "^1.4.1",
+        "colors": "^1.1.0",
+        "combine-lists": "^1.0.0",
+        "connect": "^3.3.5",
+        "core-js": "^2.2.0",
+        "di": "^0.0.1",
+        "dom-serialize": "^2.2.0",
+        "expand-braces": "^0.1.1",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "http-proxy": "^1.13.0",
+        "isbinaryfile": "^3.0.0",
+        "lodash": "^3.8.0",
+        "log4js": "^0.6.31",
+        "mime": "^1.3.4",
+        "minimatch": "^3.0.0",
+        "optimist": "^0.6.1",
+        "qjobs": "^1.1.4",
+        "rimraf": "^2.3.3",
         "socket.io": "1.4.7",
-        "source-map": "0.5.7",
+        "source-map": "^0.5.3",
         "tmp": "0.0.28",
-        "useragent": "2.2.1"
+        "useragent": "^2.1.9"
       },
       "dependencies": {
         "lodash": {
@@ -2813,8 +2842,8 @@
       "integrity": "sha1-vlrnxCZPmgouIuPZhL6zJa2SyMs=",
       "dev": true,
       "requires": {
-        "fs-access": "1.0.1",
-        "which": "1.3.0"
+        "fs-access": "^1.0.0",
+        "which": "^1.2.1"
       }
     },
     "karma-jasmine": {
@@ -2829,11 +2858,11 @@
       "integrity": "sha1-flpPsqtosMwcek+/pyu3busYyyo=",
       "dev": true,
       "requires": {
-        "async": "0.9.2",
-        "loader-utils": "0.2.17",
-        "lodash": "3.10.1",
-        "source-map": "0.1.43",
-        "webpack-dev-middleware": "1.12.0"
+        "async": "~0.9.0",
+        "loader-utils": "^0.2.5",
+        "lodash": "^3.8.0",
+        "source-map": "^0.1.41",
+        "webpack-dev-middleware": "^1.0.11"
       },
       "dependencies": {
         "lodash": {
@@ -2848,7 +2877,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -2859,7 +2888,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -2874,10 +2903,10 @@
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "dev": true,
       "requires": {
-        "big.js": "3.1.3",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1",
-        "object-assign": "4.1.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "json5": {
@@ -2900,8 +2929,8 @@
       "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34",
-        "semver": "4.3.6"
+        "readable-stream": "~1.0.2",
+        "semver": "~4.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -2916,10 +2945,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -2942,7 +2971,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "lru-cache": {
@@ -2963,8 +2992,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.4",
-        "readable-stream": "2.3.3"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       }
     },
     "micromatch": {
@@ -2973,19 +3002,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "mime": {
@@ -3006,7 +3035,7 @@
       "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
       "dev": true,
       "requires": {
-        "mime-db": "1.29.0"
+        "mime-db": "~1.29.0"
       }
     },
     "minimatch": {
@@ -3015,7 +3044,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -3058,8 +3087,8 @@
       "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
       "dev": true,
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-libs-browser": {
@@ -3068,28 +3097,28 @@
       "integrity": "sha1-JEgG1E0xngSLyGB7XMTq+aKdLjw=",
       "dev": true,
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.1.4",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^4.9.0",
+        "console-browserify": "^1.1.0",
         "constants-browserify": "0.0.1",
-        "crypto-browserify": "3.2.8",
-        "domain-browser": "1.1.7",
-        "events": "1.1.1",
-        "http-browserify": "1.7.0",
+        "crypto-browserify": "~3.2.6",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
         "https-browserify": "0.0.0",
-        "os-browserify": "0.1.2",
+        "os-browserify": "~0.1.2",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "1.1.14",
-        "stream-browserify": "1.0.0",
-        "string_decoder": "0.10.31",
-        "timers-browserify": "1.4.2",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
         "tty-browserify": "0.0.0",
-        "url": "0.10.3",
-        "util": "0.10.3",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -3105,10 +3134,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3125,7 +3154,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "null-check": {
@@ -3158,8 +3187,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "on-finished": {
@@ -3177,7 +3206,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -3186,8 +3215,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "options": {
@@ -3226,10 +3255,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parsejson": {
@@ -3238,7 +3267,7 @@
       "integrity": "sha1-mxDGwNglq1ieaFFTgm3go7oni8w=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseqs": {
@@ -3247,7 +3276,7 @@
       "integrity": "sha1-nf5wss3aw4i95PNbHyQPpYrb5sc=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseuri": {
@@ -3256,7 +3285,7 @@
       "integrity": "sha1-gGWCo5iH4eoY3V4v4OAZAiaOk1A=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseurl": {
@@ -3319,7 +3348,7 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "prop-types": {
@@ -3328,8 +3357,8 @@
       "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.14",
-        "loose-envify": "1.3.1"
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1"
       }
     },
     "prr": {
@@ -3374,8 +3403,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -3384,7 +3413,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -3393,7 +3422,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -3404,7 +3433,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -3427,29 +3456,136 @@
       }
     },
     "react": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
-      "integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
       "dev": true,
       "requires": {
-        "create-react-class": "15.6.0",
-        "fbjs": "0.8.14",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.5.10"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        },
+        "fbjs": {
+          "version": "0.8.17",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+          "dev": true,
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          },
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+              "dev": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            }
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.20",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+          "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
+          "dev": true
+        }
       }
     },
     "react-dom": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
-      "integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.14",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.5.10"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        },
+        "fbjs": {
+          "version": "0.8.17",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+          "dev": true,
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          },
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+              "dev": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            }
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.20",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+          "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
+          "dev": true
+        }
       }
+    },
+    "react-is": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+      "dev": true
     },
     "readable-stream": {
       "version": "2.3.3",
@@ -3457,13 +3593,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -3472,10 +3608,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "regenerate": {
@@ -3496,9 +3632,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.7"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -3507,8 +3643,8 @@
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "^0.1.3",
+        "is-primitive": "^2.0.0"
       }
     },
     "regexpu-core": {
@@ -3517,9 +3653,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.2",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -3534,7 +3670,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -3569,7 +3705,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "requires-port": {
@@ -3584,7 +3720,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -3593,7 +3729,7 @@
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "ripemd160": {
@@ -3837,7 +3973,7 @@
       "integrity": "sha512-A6vlydY7H/ljr4L2UOhDSajQdZQ6dMD7cLH0pzwcmwLyc9u8PNI4WGtnfDDzX7uzGL6c/T+ORL97Zlh+S4iOrg==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "statuses": {
@@ -3852,8 +3988,8 @@
       "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "1.1.14"
+        "inherits": "~2.0.1",
+        "readable-stream": "^1.0.27-1"
       },
       "dependencies": {
         "isarray": {
@@ -3868,10 +4004,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3888,7 +4024,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -3897,7 +4033,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "supports-color": {
@@ -3924,7 +4060,7 @@
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
-        "process": "0.11.10"
+        "process": "~0.11.0"
       }
     },
     "tmp": {
@@ -3933,7 +4069,7 @@
       "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.1"
       }
     },
     "to-array": {
@@ -3967,7 +4103,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.16"
+        "mime-types": "~2.1.15"
       }
     },
     "ua-parser-js": {
@@ -3982,10 +4118,10 @@
       "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "async": "~0.2.6",
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "async": {
@@ -4038,8 +4174,8 @@
       "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.2.4",
-        "tmp": "0.0.28"
+        "lru-cache": "2.2.x",
+        "tmp": "0.0.x"
       }
     },
     "utf8": {
@@ -4098,9 +4234,9 @@
       "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
       "dev": true,
       "requires": {
-        "async": "0.9.2",
-        "chokidar": "1.7.0",
-        "graceful-fs": "4.1.11"
+        "async": "^0.9.0",
+        "chokidar": "^1.0.0",
+        "graceful-fs": "^4.1.2"
       }
     },
     "webpack": {
@@ -4109,21 +4245,21 @@
       "integrity": "sha1-NlUXRDq/s8tDKZ6kRGVb6Jr/kdU=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "clone": "1.0.2",
-        "enhanced-resolve": "0.9.1",
-        "esprima": "2.7.3",
-        "interpret": "0.6.6",
-        "loader-utils": "0.2.17",
-        "memory-fs": "0.3.0",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "0.6.0",
-        "optimist": "0.6.1",
-        "supports-color": "3.2.3",
-        "tapable": "0.1.10",
-        "uglify-js": "2.6.4",
-        "watchpack": "0.2.9",
-        "webpack-core": "0.6.9"
+        "async": "^1.3.0",
+        "clone": "^1.0.2",
+        "enhanced-resolve": "~0.9.0",
+        "esprima": "^2.5.0",
+        "interpret": "^0.6.4",
+        "loader-utils": "^0.2.11",
+        "memory-fs": "~0.3.0",
+        "mkdirp": "~0.5.0",
+        "node-libs-browser": ">= 0.4.0 <=0.6.0",
+        "optimist": "~0.6.0",
+        "supports-color": "^3.1.0",
+        "tapable": "~0.1.8",
+        "uglify-js": "~2.6.0",
+        "watchpack": "^0.2.1",
+        "webpack-core": "~0.6.0"
       },
       "dependencies": {
         "async": {
@@ -4138,8 +4274,8 @@
           "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
           "dev": true,
           "requires": {
-            "errno": "0.1.4",
-            "readable-stream": "2.3.3"
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
           }
         },
         "supports-color": {
@@ -4148,7 +4284,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -4159,8 +4295,8 @@
       "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
       "dev": true,
       "requires": {
-        "source-list-map": "0.1.8",
-        "source-map": "0.4.4"
+        "source-list-map": "~0.1.7",
+        "source-map": "~0.4.1"
       },
       "dependencies": {
         "source-map": {
@@ -4169,7 +4305,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -4180,11 +4316,11 @@
       "integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
       "dev": true,
       "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "1.4.0",
-        "path-is-absolute": "1.0.1",
-        "range-parser": "1.2.0",
-        "time-stamp": "2.0.0"
+        "memory-fs": "~0.4.1",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0"
       }
     },
     "whatwg-fetch": {
@@ -4199,7 +4335,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "window-size": {
@@ -4226,8 +4362,8 @@
       "integrity": "sha1-fQsqLljN3YGQOcKcneZQReGzEOk=",
       "dev": true,
       "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
       }
     },
     "xmlhttprequest-ssl": {
@@ -4242,9 +4378,9 @@
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     },

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -621,8 +621,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  getItem: defaultGetItem,
 	  getItemKey: defaultGetItemKey,
 	  buffer: 4,
-	  scrollbarOffset: 0,
-	  debounce: false
+	  scrollbarOffset: 0
 	};
 
 	module.exports = VirtualList;

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -325,9 +325,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'handleDownwardScroll',
 	    value: function handleDownwardScroll(delta, callback) {
 	      var childNodes = this.content.childNodes;
-	      var _props2 = this.props,
-	          items = _props2.items,
-	          buffer = _props2.buffer;
+	      var items = this.props.items;
 	      var _state3 = this.state,
 	          winSize = _state3.winSize,
 	          avgRowHeight = _state3.avgRowHeight;
@@ -343,7 +341,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var startScrollTop = scrollTop;
 
 	      for (var i = 0; i < childNodes.length; i++) {
-	        if (winStart < maxWinStart && childNodes[i].offsetTop + childNodes[i].offsetHeight < startScrollTop - buffer / 2 * avgRowHeight) {
+	        if (winStart < maxWinStart && childNodes[i].offsetTop + childNodes[i].offsetHeight < startScrollTop) {
 	          winStart++;
 	          scrollTop += avgRowHeight - childNodes[i].offsetHeight;
 	        } else {
@@ -362,7 +360,6 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      var node = this.node;
 	      var childNodes = this.content.childNodes;
-	      var buffer = this.props.buffer;
 	      var _state5 = this.state,
 	          winStart = _state5.winStart,
 	          scrollTop = _state5.scrollTop,
@@ -373,7 +370,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      scrollTop += delta;
 
 	      for (var i = childNodes.length - 1; i >= 0; i--) {
-	        if (winStart > 0 && childNodes[i].offsetTop - scrollTop - buffer / 2 * avgRowHeight > node.offsetHeight) {
+	        if (winStart > 0 && childNodes[i].offsetTop - scrollTop > node.offsetHeight) {
 	          winStart--;
 	          n++;
 	        } else {
@@ -509,11 +506,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    value: function render() {
 	      var _this4 = this;
 
-	      var _props3 = this.props,
-	          items = _props3.items,
-	          getItem = _props3.getItem,
-	          getItemKey = _props3.getItemKey,
-	          scrollbarOffset = _props3.scrollbarOffset;
+	      var _props2 = this.props,
+	          items = _props2.items,
+	          getItem = _props2.getItem,
+	          getItemKey = _props2.getItemKey,
+	          scrollbarOffset = _props2.scrollbarOffset;
 	      var _state9 = this.state,
 	          winStart = _state9.winStart,
 	          winSize = _state9.winSize,

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -229,6 +229,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 	      this.notifyFirstVisibleItemIfNecessary();
+	      this.notifyLastVisibleItemIfNecessary();
 
 	      if (childNodes.length < winSize) {
 	        this.sampleRowHeights();
@@ -304,6 +305,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	      }
 	    }
 	  }, {
+	    key: 'notifyLastVisibleItemIfNecessary',
+	    value: function notifyLastVisibleItemIfNecessary() {
+	      if (!this.props.onLastVisibleItemChange) {
+	        return;
+	      }
+
+	      var idx = this.findLastVisibleItemIndex();
+
+	      if (this._lastIndex !== idx) {
+	        this.props.onLastVisibleItemChange(this.props.items[idx], idx);
+	        this._lastIndex = idx;
+	      }
+	    }
+	  }, {
 	    key: 'findFirstVisibleItemIndex',
 	    value: function findFirstVisibleItemIndex() {
 	      var childNodes = this.content.childNodes;
@@ -322,18 +337,37 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return undefined;
 	    }
 	  }, {
+	    key: 'findLastVisibleItemIndex',
+	    value: function findLastVisibleItemIndex() {
+	      var childNodes = this.content.childNodes;
+	      var items = this.props.items;
+	      var _state3 = this.state,
+	          winStart = _state3.winStart,
+	          scrollTop = _state3.scrollTop,
+	          viewportHeight = _state3.viewportHeight;
+
+
+	      for (var i = childNodes.length - 1; i >= 0; i--) {
+	        if (childNodes[i].offsetTop < scrollTop + viewportHeight) {
+	          return winStart + i;
+	        }
+	      }
+
+	      return undefined;
+	    }
+	  }, {
 	    key: 'handleDownwardScroll',
 	    value: function handleDownwardScroll(delta, callback) {
 	      var childNodes = this.content.childNodes;
 	      var items = this.props.items;
-	      var _state3 = this.state,
-	          winSize = _state3.winSize,
-	          avgRowHeight = _state3.avgRowHeight;
+	      var _state4 = this.state,
+	          winSize = _state4.winSize,
+	          avgRowHeight = _state4.avgRowHeight;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
-	      var _state4 = this.state,
-	          winStart = _state4.winStart,
-	          scrollTop = _state4.scrollTop;
+	      var _state5 = this.state,
+	          winStart = _state5.winStart,
+	          scrollTop = _state5.scrollTop;
 
 
 	      scrollTop += delta;
@@ -360,10 +394,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      var node = this.node;
 	      var childNodes = this.content.childNodes;
-	      var _state5 = this.state,
-	          winStart = _state5.winStart,
-	          scrollTop = _state5.scrollTop,
-	          avgRowHeight = _state5.avgRowHeight;
+	      var _state6 = this.state,
+	          winStart = _state6.winStart,
+	          scrollTop = _state6.scrollTop,
+	          avgRowHeight = _state6.avgRowHeight;
 
 	      var n = 0;
 
@@ -397,9 +431,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'handleLongScroll',
 	    value: function handleLongScroll(delta, callback) {
 	      var items = this.props.items;
-	      var _state6 = this.state,
-	          winSize = _state6.winSize,
-	          avgRowHeight = _state6.avgRowHeight;
+	      var _state7 = this.state,
+	          winSize = _state7.winSize,
+	          avgRowHeight = _state7.avgRowHeight;
 	      var scrollTop = this.state.scrollTop;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
@@ -429,9 +463,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'scrollToIndex',
 	    value: function scrollToIndex(index, callback) {
 	      var items = this.props.items;
-	      var _state7 = this.state,
-	          winSize = _state7.winSize,
-	          avgRowHeight = _state7.avgRowHeight;
+	      var _state8 = this.state,
+	          winSize = _state8.winSize,
+	          avgRowHeight = _state8.avgRowHeight;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
 	      var winStart = Math.min(maxWinStart, index);
@@ -467,9 +501,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'itemsMutated',
 	    value: function itemsMutated(callback) {
 	      var items = this.props.items;
-	      var _state8 = this.state,
-	          winStart = _state8.winStart,
-	          winSize = _state8.winSize;
+	      var _state9 = this.state,
+	          winStart = _state9.winStart,
+	          winSize = _state9.winSize;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
 
@@ -512,10 +546,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	          getItem = _props2.getItem,
 	          getItemKey = _props2.getItemKey,
 	          scrollbarOffset = _props2.scrollbarOffset;
-	      var _state9 = this.state,
-	          winStart = _state9.winStart,
-	          winSize = _state9.winSize,
-	          avgRowHeight = _state9.avgRowHeight;
+	      var _state10 = this.state,
+	          winStart = _state10.winStart,
+	          winSize = _state10.winSize,
+	          avgRowHeight = _state10.avgRowHeight;
 
 	      var winEnd = Math.min(items.length - 1, winStart + winSize - 1);
 	      var paddingTop = winStart * avgRowHeight;

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -443,8 +443,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return this;
 	    }
 	  }, {
-	    key: 'scrollToIndex',
-	    value: function scrollToIndex(index, callback) {
+	    key: '_scrollToIndex',
+	    value: function _scrollToIndex(index, callback) {
 	      var items = this.props.items;
 	      var _state9 = this.state,
 	          winSize = _state9.winSize,
@@ -455,6 +455,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var scrollTop = winStart * avgRowHeight;
 
 	      this.setState({ winStart: winStart, scrollTop: scrollTop }, callback);
+	    }
+	  }, {
+	    key: 'scrollToIndex',
+	    value: function scrollToIndex(index, callback) {
+	      var _this4 = this;
+
+	      if (this.state.avgRowHeight === 1) {
+	        // The average row height is still the initial value, which means that we
+	        // haven't sampled the row heights yet, which we need in order to properly
+	        // scroll to the right position. So we need to delay the scroll logic
+	        // until after the list has had a chance to sample the row heights.
+	        this.setState({}, function () {
+	          _this4._scrollToIndex(index, callback);
+	        });
+	      } else {
+	        this._scrollToIndex(index, callback);
+	      }
 	    }
 	  }, {
 	    key: 'scrollToItem',
@@ -514,7 +531,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }, {
 	    key: 'render',
 	    value: function render() {
-	      var _this4 = this;
+	      var _this5 = this;
 
 	      var _props2 = this.props,
 	          items = _props2.items,
@@ -561,7 +578,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        'div',
 	        {
 	          ref: function ref(node) {
-	            _this4.node = node;
+	            _this5.node = node;
 	          },
 	          className: 'VirtualList',
 	          tabIndex: '-1',
@@ -571,7 +588,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	          'div',
 	          {
 	            ref: function ref(content) {
-	              _this4.content = content;
+	              _this5.content = content;
 	            },
 	            className: 'VirtualList-content',
 	            style: contentStyle },

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -161,12 +161,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  // Internal: After the component is mounted we do the following:
 	  //
-	  // 1. Start a timer to periodically check for resizes of the container. When the container is
-	  //    resized we have to adjust the display window to ensure that we are rendering enough items
-	  //    to fill the viewport.
-	  // 2. Calculate the initial viewport height and display window size by triggering the resize
-	  //    handler.
-	  // 3. Sample the just rendered row heights to get an average row height to use while handling
+	  // 1. Start a requestAnimationFrame loop that checks for resize and scroll updates. When the
+	  //    container is resized we have to adjust the display window to ensure that we are rendering
+	  //    enough items to fill the viewport. When the container is scrolled we need to adjust the
+	  //    rendered window and item positions.
+	  // 2. Sample the just rendered row heights to get an average row height to use while handling
 	  //    scroll events.
 
 
@@ -212,6 +211,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	    value: function componentWillUnmount() {
 	      cancelAnimationFrame(this._raf);
 	    }
+
+	    // Internal: This method gets called on each animation frame. It checks for the following:
+	    //
+	    // 1. Viewport height changes. When the viewport height has changed, we need to adjust the render
+	    //    window to ensure that we have enough items to fill it.
+	    // 2. Sroll changes. If the container has been scrolled since the last time we renedered we may
+	    //    need to adjust the render window.
+
 	  }, {
 	    key: 'animationLoop',
 	    value: function animationLoop() {

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -296,16 +296,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	        return;
 	      }
 
-	      var first = this.findFirstVisibleItem();
+	      var idx = this.findFirstVisibleItemIndex();
 
-	      if (this._first !== first) {
-	        this.props.onFirstVisibleItemChange(first);
-	        this._first = first;
+	      if (this._firstIndex !== idx) {
+	        this.props.onFirstVisibleItemChange(this.props.items[idx], idx);
+	        this._firstIndex = idx;
 	      }
 	    }
 	  }, {
-	    key: 'findFirstVisibleItem',
-	    value: function findFirstVisibleItem() {
+	    key: 'findFirstVisibleItemIndex',
+	    value: function findFirstVisibleItemIndex() {
 	      var childNodes = this.content.childNodes;
 	      var items = this.props.items;
 	      var _state2 = this.state,
@@ -315,7 +315,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      for (var i = 0; i < childNodes.length; i++) {
 	        if (childNodes[i].offsetTop + childNodes[i].offsetHeight >= scrollTop) {
-	          return items[winStart + i];
+	          return winStart + i;
 	        }
 	      }
 
@@ -405,7 +405,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var maxWinStart = Math.max(0, items.length - winSize);
 	      scrollTop += delta;
 	      this.setState({
-	        winStart: Math.min(maxWinStart, Math.floor(scrollTop / avgRowHeight)), scrollTop: scrollTop
+	        winStart: Math.min(maxWinStart, Math.floor(scrollTop / avgRowHeight)),
+	        scrollTop: scrollTop
 	      }, callback);
 	    }
 	  }, {
@@ -528,26 +529,43 @@ return /******/ (function(modules) { // webpackBootstrap
 	        overflowY: 'auto',
 	        overflowX: scrollbarOffset ? 'hidden' : undefined
 	      }, this.props.style);
-	      var contentStyle = { paddingTop: paddingTop, paddingBottom: paddingBottom, marginRight: -scrollbarOffset };
+	      var contentStyle = {
+	        paddingTop: paddingTop,
+	        paddingBottom: paddingBottom,
+	        marginRight: -scrollbarOffset
+	      };
 	      var itemView = _react2.default.Children.only(this.props.children);
 	      var itemNodes = [];
 	      var item = void 0;
 
 	      for (var i = winStart; i <= winEnd; i++) {
 	        item = getItem(items, i);
-	        itemNodes.push(_react2.default.createElement(Item, { key: getItemKey(item, i), itemIndex: i, itemView: itemView, item: item }));
+	        itemNodes.push(_react2.default.createElement(Item, {
+	          key: getItemKey(item, i),
+	          itemIndex: i,
+	          itemView: itemView,
+	          item: item
+	        }));
 	      }
 
 	      return _react2.default.createElement(
 	        'div',
-	        { ref: function ref(node) {
+	        {
+	          ref: function ref(node) {
 	            _this4.node = node;
-	          }, className: 'VirtualList', tabIndex: '-1', style: style, onScroll: this.onScroll },
+	          },
+	          className: 'VirtualList',
+	          tabIndex: '-1',
+	          style: style,
+	          onScroll: this.onScroll },
 	        _react2.default.createElement(
 	          'div',
-	          { ref: function ref(content) {
+	          {
+	            ref: function ref(content) {
 	              _this4.content = content;
-	            }, className: 'VirtualList-content', style: contentStyle },
+	            },
+	            className: 'VirtualList-content',
+	            style: contentStyle },
 	          itemNodes
 	        )
 	      );

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -155,8 +155,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      scrollTop: 0
 	    };
 
-	    _this2.checkForResize = _this2.checkForResize.bind(_this2);
-	    _this2.handleScroll = _this2.handleScroll.bind(_this2);
+	    _this2.animationLoop = _this2.animationLoop.bind(_this2);
 	    return _this2;
 	  }
 
@@ -174,10 +173,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  _createClass(VirtualList, [{
 	    key: 'componentDidMount',
 	    value: function componentDidMount() {
-	      this._resizeTimer = setInterval(this.checkForResize, this.props.resizeInterval);
-	      this.handleResize();
+	      this.animationLoop();
 	      this.sampleRowHeights();
-	      this.handleScroll();
 	    }
 
 	    // Internal: After the component is updated we do the following:
@@ -213,19 +210,26 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }, {
 	    key: 'componentWillUnmount',
 	    value: function componentWillUnmount() {
-	      clearInterval(this._resizeTimer);
-	      cancelAnimationFrame(this._handleScrollRAF);
+	      cancelAnimationFrame(this._raf);
 	    }
 	  }, {
-	    key: 'checkForResize',
-	    value: function checkForResize() {
-	      var clientHeight = this.node.clientHeight;
-	      var viewportHeight = this.state.viewportHeight;
+	    key: 'animationLoop',
+	    value: function animationLoop() {
+	      var node = this.node;
+	      var _state2 = this.state,
+	          scrollTop = _state2.scrollTop,
+	          viewportHeight = _state2.viewportHeight;
 
 
-	      if (clientHeight !== viewportHeight) {
+	      if (node.clientHeight !== viewportHeight) {
 	        this.handleResize();
 	      }
+
+	      if (node.scrollTop !== scrollTop) {
+	        this.scroll(node.scrollTop - scrollTop);
+	      }
+
+	      this._raf = requestAnimationFrame(this.animationLoop);
 	    }
 
 	    // Internal: When the container node has been resized we need to adjust the internal
@@ -295,9 +299,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    value: function findFirstVisibleItemIndex() {
 	      var childNodes = this.content.childNodes;
 	      var items = this.props.items;
-	      var _state2 = this.state,
-	          winStart = _state2.winStart,
-	          scrollTop = _state2.scrollTop;
+	      var _state3 = this.state,
+	          winStart = _state3.winStart,
+	          scrollTop = _state3.scrollTop;
 
 
 	      for (var i = 0; i < childNodes.length; i++) {
@@ -313,10 +317,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    value: function findLastVisibleItemIndex() {
 	      var childNodes = this.content.childNodes;
 	      var items = this.props.items;
-	      var _state3 = this.state,
-	          winStart = _state3.winStart,
-	          scrollTop = _state3.scrollTop,
-	          viewportHeight = _state3.viewportHeight;
+	      var _state4 = this.state,
+	          winStart = _state4.winStart,
+	          scrollTop = _state4.scrollTop,
+	          viewportHeight = _state4.viewportHeight;
 
 
 	      for (var i = childNodes.length - 1; i >= 0; i--) {
@@ -332,14 +336,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	    value: function handleDownwardScroll(delta, callback) {
 	      var childNodes = this.content.childNodes;
 	      var items = this.props.items;
-	      var _state4 = this.state,
-	          winSize = _state4.winSize,
-	          avgRowHeight = _state4.avgRowHeight;
+	      var _state5 = this.state,
+	          winSize = _state5.winSize,
+	          avgRowHeight = _state5.avgRowHeight;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
-	      var _state5 = this.state,
-	          winStart = _state5.winStart,
-	          scrollTop = _state5.scrollTop;
+	      var _state6 = this.state,
+	          winStart = _state6.winStart,
+	          scrollTop = _state6.scrollTop;
 
 
 	      scrollTop += delta;
@@ -366,10 +370,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      var node = this.node;
 	      var childNodes = this.content.childNodes;
-	      var _state6 = this.state,
-	          winStart = _state6.winStart,
-	          scrollTop = _state6.scrollTop,
-	          avgRowHeight = _state6.avgRowHeight;
+	      var _state7 = this.state,
+	          winStart = _state7.winStart,
+	          scrollTop = _state7.scrollTop,
+	          avgRowHeight = _state7.avgRowHeight;
 
 	      var n = 0;
 
@@ -403,9 +407,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'handleLongScroll',
 	    value: function handleLongScroll(delta, callback) {
 	      var items = this.props.items;
-	      var _state7 = this.state,
-	          winSize = _state7.winSize,
-	          avgRowHeight = _state7.avgRowHeight;
+	      var _state8 = this.state,
+	          winSize = _state8.winSize,
+	          avgRowHeight = _state8.avgRowHeight;
 	      var scrollTop = this.state.scrollTop;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
@@ -435,9 +439,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'scrollToIndex',
 	    value: function scrollToIndex(index, callback) {
 	      var items = this.props.items;
-	      var _state8 = this.state,
-	          winSize = _state8.winSize,
-	          avgRowHeight = _state8.avgRowHeight;
+	      var _state9 = this.state,
+	          winSize = _state9.winSize,
+	          avgRowHeight = _state9.avgRowHeight;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
 	      var winStart = Math.min(maxWinStart, index);
@@ -473,9 +477,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'itemsMutated',
 	    value: function itemsMutated(callback) {
 	      var items = this.props.items;
-	      var _state9 = this.state,
-	          winStart = _state9.winStart,
-	          winSize = _state9.winSize;
+	      var _state10 = this.state,
+	          winStart = _state10.winStart,
+	          winSize = _state10.winSize;
 
 	      var maxWinStart = Math.max(0, items.length - winSize);
 
@@ -510,10 +514,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	          getItem = _props2.getItem,
 	          getItemKey = _props2.getItemKey,
 	          scrollbarOffset = _props2.scrollbarOffset;
-	      var _state10 = this.state,
-	          winStart = _state10.winStart,
-	          winSize = _state10.winSize,
-	          avgRowHeight = _state10.avgRowHeight;
+	      var _state11 = this.state,
+	          winStart = _state11.winStart,
+	          winSize = _state11.winSize,
+	          avgRowHeight = _state11.avgRowHeight;
 
 	      var winEnd = Math.min(items.length - 1, winStart + winSize - 1);
 	      var paddingTop = winStart * avgRowHeight;
@@ -602,11 +606,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  // Offset the scrollbar by the number of pixels specified. The default is 0.
 	  scrollbarOffset: _propTypes2.default.number,
 
-	  // Specify how often to check for a resize of the component in milliseconds. The virtual list
-	  // must recompute its window size when the component is resized because it may no longer be
-	  // large enough to fill the viewport. Default is 1000ms.
-	  resizeInterval: _propTypes2.default.number,
-
 	  // Style object applied to the container.
 	  style: _propTypes2.default.object
 	};
@@ -616,7 +615,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  getItemKey: defaultGetItemKey,
 	  buffer: 4,
 	  scrollbarOffset: 0,
-	  resizeInterval: 1000,
 	  debounce: false
 	};
 

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -102,35 +102,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return Item;
 	}(_react2.default.PureComponent);
 
-	var debounce = function debounce(func, wait) {
-	  var timeout = void 0,
-	      result = void 0;
-	  var later = function later(context, args) {
-	    timeout = null;
-	    if (args) result = func.apply(context, args);
-	  };
-	  var delay = function delay(func, wait) {
-	    for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
-	      args[_key - 2] = arguments[_key];
-	    }
-
-	    return setTimeout(function () {
-	      return func.apply(null, args);
-	    }, wait);
-	  };
-	  var debounced = function debounced() {
-	    for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
-	      args[_key2] = arguments[_key2];
-	    }
-
-	    if (timeout) clearTimeout(timeout);
-	    timeout = delay(later, wait, undefined, args);
-	    return result;
-	  };
-
-	  return debounced;
-	};
-
 	function defaultGetItem(items, index) {
 	  return items[index];
 	}
@@ -184,9 +155,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      scrollTop: 0
 	    };
 
-	    _this2.onScroll = _this2.onScroll.bind(_this2);
-	    _this2.debouncedOnScroll = props.debounce ? debounce(_this2.debouncedOnScroll.bind(_this2), 30) : _this2.debouncedOnScroll;
 	    _this2.checkForResize = _this2.checkForResize.bind(_this2);
+	    _this2.handleScroll = _this2.handleScroll.bind(_this2);
 	    return _this2;
 	  }
 
@@ -207,6 +177,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      this._resizeTimer = setInterval(this.checkForResize, this.props.resizeInterval);
 	      this.handleResize();
 	      this.sampleRowHeights();
+	      this.handleScroll();
 	    }
 
 	    // Internal: After the component is updated we do the following:
@@ -243,6 +214,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'componentWillUnmount',
 	    value: function componentWillUnmount() {
 	      clearInterval(this._resizeTimer);
+	      cancelAnimationFrame(this._handleScrollRAF);
 	    }
 	  }, {
 	    key: 'checkForResize',
@@ -516,17 +488,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return this;
 	    }
 	  }, {
-	    key: 'onScroll',
-	    value: function onScroll(e) {
-	      e.persist();
-	      if (e.target.scrollTop === this.state.scrollTop) {
-	        this.props.onScroll && this.props.onScroll(e);
-	      }
-	      this.debouncedOnScroll(e);
-	    }
-	  }, {
-	    key: 'debouncedOnScroll',
-	    value: function debouncedOnScroll(e) {
+	    key: 'handleScroll',
+	    value: function handleScroll() {
 	      var node = this.node;
 	      var scrollTop = this.state.scrollTop;
 
@@ -534,7 +497,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      if (node.scrollTop !== scrollTop) {
 	        this.scroll(node.scrollTop - scrollTop);
 	      }
-	      this.props.onScroll && this.props.onScroll(e);
+
+	      this._handleScrollRAF = requestAnimationFrame(this.handleScroll);
 	    }
 	  }, {
 	    key: 'render',
@@ -591,7 +555,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	          className: 'VirtualList',
 	          tabIndex: '-1',
 	          style: style,
-	          onScroll: this.onScroll },
+	          onScroll: this.props.onScroll },
 	        _react2.default.createElement(
 	          'div',
 	          {
@@ -644,10 +608,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  resizeInterval: _propTypes2.default.number,
 
 	  // Style object applied to the container.
-	  style: _propTypes2.default.object,
-
-	  // Specify whether to debounce onScroll handler
-	  debounce: _propTypes2.default.bool
+	  style: _propTypes2.default.object
 	};
 
 	VirtualList.defaultProps = {

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -340,8 +340,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	      scrollTop += delta;
 
+	      var startScrollTop = scrollTop;
+
 	      for (var i = 0; i < childNodes.length; i++) {
-	        if (winStart < maxWinStart && childNodes[i].offsetTop + childNodes[i].offsetHeight < scrollTop - buffer / 2 * avgRowHeight) {
+	        if (winStart < maxWinStart && childNodes[i].offsetTop + childNodes[i].offsetHeight < startScrollTop - buffer / 2 * avgRowHeight) {
 	          winStart++;
 	          scrollTop += avgRowHeight - childNodes[i].offsetHeight;
 	        } else {

--- a/spec/VirtualList_spec.js
+++ b/spec/VirtualList_spec.js
@@ -221,7 +221,7 @@ describe('VirtualList', function() {
         expect(this.onFirstVisibleItemChange.calls.count()).toBe(1);
         this.list.scroll(2, () => {
           expect(this.onFirstVisibleItemChange.calls.count()).toBe(2);
-          expect(this.onFirstVisibleItemChange).toHaveBeenCalledWith(this.items[1]);
+          expect(this.onFirstVisibleItemChange).toHaveBeenCalledWith(this.items[1], 1);
           done();
         });
       });

--- a/spec/VirtualList_spec.js
+++ b/spec/VirtualList_spec.js
@@ -123,9 +123,9 @@ describe('VirtualList', function() {
     });
   });
 
-  describe('scrolling without buffer', function() {
+  describe('scrolling', function() {
     beforeEach(function() {
-      this.setupList({ buffer: 0 });
+      this.setupList();
     });
 
     describe('on a short downward scroll', function() {
@@ -170,21 +170,6 @@ describe('VirtualList', function() {
         // 6 items at 40px each of height are rendered at the beginning
         // 600px - 1px scroll + (6 * 10px difference)
         expect(this.list.state.scrollTop).toBe(659);
-      });
-    });
-  });
-
-  describe('scrolling, with default buffer of 4', function() {
-    describe('on a short downward scroll', function() {
-      it('it keeps half the buffer (2) on top of the list', function(done) {
-        this.list.scroll(80, () => {
-          expect(this.list.state.winStart).toBe(0);
-
-          this.list.scroll(40, () => {
-            expect(this.list.state.winStart).toBe(1);
-            done();
-          });
-        });
       });
     });
   });

--- a/spec/VirtualList_spec.js
+++ b/spec/VirtualList_spec.js
@@ -1,19 +1,33 @@
-import VirtualList from "../src/VirtualList.jsx";
-import React from "react";
+import VirtualList from '../src/VirtualList.jsx';
+import React from 'react';
 import ReactDOM from 'react-dom';
-import RT from "react-dom/test-utils";
+import RT from 'react-dom/test-utils';
 
 class Container extends React.Component {
   render() {
     return (
-      <div style={{ position: 'absolute', top: 0, right: 0, bottom: 0, left: 0, overflow: 'hidden' }}>
-        <VirtualList ref={el => { this.list = el; }} {...this.props}><ItemView /></VirtualList>
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          overflow: 'hidden',
+        }}>
+        <VirtualList
+          ref={el => {
+            this.list = el;
+          }}
+          {...this.props}>
+          <ItemView />
+        </VirtualList>
       </div>
     );
   }
-};
+}
 
-const ItemView = ({item}) => <div style={{ height: item.height }}>{item.id}</div>
+const ItemView = ({item}) => <div style={{height: item.height}}>{item.id}</div>;
 
 describe('VirtualList', function() {
   beforeEach(function(done) {
@@ -35,27 +49,34 @@ describe('VirtualList', function() {
       {id: 6, height: 30},
       {id: 7, height: 20},
       {id: 8, height: 20},
-      {id: 9, height: 40}
+      {id: 9, height: 40},
     ];
 
     for (let i = 10; i < 100; i++) {
       this.items.push({id: i, height: 40});
     }
 
-    this.onFirstVisibleItemChange = jasmine.createSpy('onFirstVisibleItemChange');
+    this.onFirstVisibleItemChange = jasmine.createSpy(
+      'onFirstVisibleItemChange',
+    );
+    this.onLastVisibleItemChange = jasmine.createSpy('onLastVisibleItemChange');
 
-    this.setupList = (props) => {
+    this.setupList = props => {
       ReactDOM.render(
         <Container
           items={this.items}
-          ref={el => { this.container = el }}
+          ref={el => {
+            this.container = el;
+          }}
           onFirstVisibleItemChange={this.onFirstVisibleItemChange}
+          onLastVisibleItemChange={this.onLastVisibleItemChange}
           {...props}
-        />, this.wrapper
+        />,
+        this.wrapper,
       );
     };
 
-    this.setupList()
+    this.setupList();
 
     setTimeout(() => {
       this.list = this.container.list;
@@ -63,7 +84,6 @@ describe('VirtualList', function() {
       this.contentNode = this.node.querySelector('.VirtualList-content');
       done();
     });
-
   });
 
   afterEach(function() {
@@ -82,7 +102,7 @@ describe('VirtualList', function() {
 
     it('calculates the window size based on the viewportHeight and average row height', function() {
       expect(this.list.state.winSize).toBe(11);
-    })
+    });
   });
 
   describe('#render', function() {
@@ -109,17 +129,17 @@ describe('VirtualList', function() {
 
     it('sets the item prop on each item view to the appropriate item object', function() {
       let itemNodes = this.node.querySelectorAll('.VirtualList-item');
-      expect(itemNodes[0].textContent).toEqual("0");
-      expect(itemNodes[1].textContent).toEqual("1");
-      expect(itemNodes[2].textContent).toEqual("2");
-      expect(itemNodes[3].textContent).toEqual("3");
-      expect(itemNodes[4].textContent).toEqual("4");
-      expect(itemNodes[5].textContent).toEqual("5");
-      expect(itemNodes[6].textContent).toEqual("6");
-      expect(itemNodes[7].textContent).toEqual("7");
-      expect(itemNodes[8].textContent).toEqual("8");
-      expect(itemNodes[9].textContent).toEqual("9");
-      expect(itemNodes[10].textContent).toEqual("10");
+      expect(itemNodes[0].textContent).toEqual('0');
+      expect(itemNodes[1].textContent).toEqual('1');
+      expect(itemNodes[2].textContent).toEqual('2');
+      expect(itemNodes[3].textContent).toEqual('3');
+      expect(itemNodes[4].textContent).toEqual('4');
+      expect(itemNodes[5].textContent).toEqual('5');
+      expect(itemNodes[6].textContent).toEqual('6');
+      expect(itemNodes[7].textContent).toEqual('7');
+      expect(itemNodes[8].textContent).toEqual('8');
+      expect(itemNodes[9].textContent).toEqual('9');
+      expect(itemNodes[10].textContent).toEqual('10');
     });
   });
 
@@ -221,7 +241,28 @@ describe('VirtualList', function() {
         expect(this.onFirstVisibleItemChange.calls.count()).toBe(1);
         this.list.scroll(2, () => {
           expect(this.onFirstVisibleItemChange.calls.count()).toBe(2);
-          expect(this.onFirstVisibleItemChange).toHaveBeenCalledWith(this.items[1], 1);
+          expect(this.onFirstVisibleItemChange).toHaveBeenCalledWith(
+            this.items[1],
+            1,
+          );
+          done();
+        });
+      });
+    });
+  });
+
+  describe('onLastVisibleItemChange callback', function() {
+    it('gets invoked after a scroll changes which item is the last visibile', function(done) {
+      expect(this.onLastVisibleItemChange.calls.count()).toBe(1);
+
+      this.list.scroll(19, () => {
+        expect(this.onLastVisibleItemChange.calls.count()).toBe(1);
+        this.list.scroll(2, () => {
+          expect(this.onLastVisibleItemChange.calls.count()).toBe(2);
+          expect(this.onLastVisibleItemChange).toHaveBeenCalledWith(
+            this.items[7],
+            7,
+          );
           done();
         });
       });
@@ -240,11 +281,11 @@ describe('VirtualList', function() {
       });
     });
 
-    it("re-renders when an item is replaced", function(done) {
+    it('re-renders when an item is replaced', function(done) {
       this.items[0] = {id: 9999, height: 40};
       this.list.itemsMutated(() => {
         let itemNodes = this.node.querySelectorAll('.VirtualList-item');
-        expect(itemNodes[0].textContent).toEqual("9999");
+        expect(itemNodes[0].textContent).toEqual('9999');
         done();
       });
     });

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -119,6 +119,7 @@ class VirtualList extends React.Component {
     const {winSize, scrollTop} = this.state;
 
     this.notifyFirstVisibleItemIfNecessary();
+    this.notifyLastVisibleItemIfNecessary();
 
     if (childNodes.length < winSize) {
       this.sampleRowHeights();
@@ -193,6 +194,19 @@ class VirtualList extends React.Component {
     }
   }
 
+  notifyLastVisibleItemIfNecessary() {
+    if (!this.props.onLastVisibleItemChange) {
+      return;
+    }
+
+    const idx = this.findLastVisibleItemIndex();
+
+    if (this._lastIndex !== idx) {
+      this.props.onLastVisibleItemChange(this.props.items[idx], idx);
+      this._lastIndex = idx;
+    }
+  }
+
   findFirstVisibleItemIndex() {
     const childNodes = this.content.childNodes;
     const {items} = this.props;
@@ -200,6 +214,20 @@ class VirtualList extends React.Component {
 
     for (let i = 0; i < childNodes.length; i++) {
       if (childNodes[i].offsetTop + childNodes[i].offsetHeight >= scrollTop) {
+        return winStart + i;
+      }
+    }
+
+    return undefined;
+  }
+
+  findLastVisibleItemIndex() {
+    const childNodes = this.content.childNodes;
+    const {items} = this.props;
+    const {winStart, scrollTop, viewportHeight} = this.state;
+
+    for (let i = childNodes.length - 1; i >= 0; i--) {
+      if (childNodes[i].offsetTop < scrollTop + viewportHeight) {
         return winStart + i;
       }
     }

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -468,7 +468,6 @@ VirtualList.defaultProps = {
   getItemKey: defaultGetItemKey,
   buffer: 4,
   scrollbarOffset: 0,
-  debounce: false,
 };
 
 module.exports = VirtualList;

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -193,8 +193,10 @@ class VirtualList extends React.Component {
 
     scrollTop += delta;
 
+    const startScrollTop = scrollTop;
+
     for (let i = 0; i < childNodes.length; i++) {
-      if (winStart < maxWinStart && childNodes[i].offsetTop + childNodes[i].offsetHeight < scrollTop - (buffer / 2 * avgRowHeight)) {
+      if (winStart < maxWinStart && childNodes[i].offsetTop + childNodes[i].offsetHeight < startScrollTop - (buffer / 2 * avgRowHeight)) {
         winStart++;
         scrollTop += avgRowHeight - childNodes[i].offsetHeight;
       }

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -65,12 +65,11 @@ class VirtualList extends React.Component {
 
   // Internal: After the component is mounted we do the following:
   //
-  // 1. Start a timer to periodically check for resizes of the container. When the container is
-  //    resized we have to adjust the display window to ensure that we are rendering enough items
-  //    to fill the viewport.
-  // 2. Calculate the initial viewport height and display window size by triggering the resize
-  //    handler.
-  // 3. Sample the just rendered row heights to get an average row height to use while handling
+  // 1. Start a requestAnimationFrame loop that checks for resize and scroll updates. When the
+  //    container is resized we have to adjust the display window to ensure that we are rendering
+  //    enough items to fill the viewport. When the container is scrolled we need to adjust the
+  //    rendered window and item positions.
+  // 2. Sample the just rendered row heights to get an average row height to use while handling
   //    scroll events.
   componentDidMount() {
     this.animationLoop();
@@ -106,6 +105,12 @@ class VirtualList extends React.Component {
     cancelAnimationFrame(this._raf);
   }
 
+  // Internal: This method gets called on each animation frame. It checks for the following:
+  //
+  // 1. Viewport height changes. When the viewport height has changed, we need to adjust the render
+  //    window to ensure that we have enough items to fill it.
+  // 2. Sroll changes. If the container has been scrolled since the last time we renedered we may
+  //    need to adjust the render window.
   animationLoop() {
     const node = this.node;
     const { scrollTop, viewportHeight } = this.state;

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -311,7 +311,7 @@ class VirtualList extends React.Component {
     return this;
   }
 
-  scrollToIndex(index, callback) {
+  _scrollToIndex(index, callback) {
     const {items} = this.props;
     const {winSize, avgRowHeight} = this.state;
     const maxWinStart = Math.max(0, items.length - winSize);
@@ -319,6 +319,20 @@ class VirtualList extends React.Component {
     let scrollTop = winStart * avgRowHeight;
 
     this.setState({winStart, scrollTop}, callback);
+  }
+
+  scrollToIndex(index, callback) {
+    if (this.state.avgRowHeight === 1) {
+      // The average row height is still the initial value, which means that we
+      // haven't sampled the row heights yet, which we need in order to properly
+      // scroll to the right position. So we need to delay the scroll logic
+      // until after the list has had a chance to sample the row heights.
+      this.setState({}, () => {
+        this._scrollToIndex(index, callback);
+      });
+    } else {
+      this._scrollToIndex(index, callback);
+    }
   }
 
   scrollToItem(item, callback) {

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -186,7 +186,7 @@ class VirtualList extends React.Component {
 
   handleDownwardScroll(delta, callback) {
     const childNodes = this.content.childNodes;
-    const { items, buffer } = this.props;
+    const { items } = this.props;
     const { winSize, avgRowHeight } = this.state;
     const maxWinStart = Math.max(0, items.length - winSize);
     let { winStart, scrollTop } = this.state;
@@ -196,7 +196,7 @@ class VirtualList extends React.Component {
     const startScrollTop = scrollTop;
 
     for (let i = 0; i < childNodes.length; i++) {
-      if (winStart < maxWinStart && childNodes[i].offsetTop + childNodes[i].offsetHeight < startScrollTop - (buffer / 2 * avgRowHeight)) {
+      if (winStart < maxWinStart && childNodes[i].offsetTop + childNodes[i].offsetHeight < startScrollTop) {
         winStart++;
         scrollTop += avgRowHeight - childNodes[i].offsetHeight;
       }
@@ -213,14 +213,13 @@ class VirtualList extends React.Component {
   handleUpwardScroll(delta, callback) {
     const node = this.node;
     const childNodes = this.content.childNodes;
-    const { buffer } = this.props;
     let { winStart, scrollTop, avgRowHeight } = this.state;
     let n = 0;
 
     scrollTop += delta;
 
     for (let i = childNodes.length - 1; i >= 0; i--) {
-      if (winStart > 0 && (childNodes[i].offsetTop - scrollTop - (buffer / 2 * avgRowHeight)) > node.offsetHeight) {
+      if (winStart > 0 && (childNodes[i].offsetTop - scrollTop) > node.offsetHeight) {
         winStart--;
         n++;
       }

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -3,9 +3,11 @@ import PropTypes from 'prop-types';
 
 class Item extends React.PureComponent {
   render() {
-    const { itemIndex, itemView, item } = this.props;
+    const {itemIndex, itemView, item} = this.props;
     return (
-      <div className="VirtualList-item">{ React.cloneElement(itemView, { itemIndex, item })}</div>
+      <div className="VirtualList-item">
+        {React.cloneElement(itemView, {itemIndex, item})}
+      </div>
     );
   }
 }
@@ -30,9 +32,13 @@ const debounce = (func, wait) => {
   return debounced;
 };
 
-function defaultGetItem(items, index) { return items[index]; }
+function defaultGetItem(items, index) {
+  return items[index];
+}
 
-function defaultGetItemKey(item, index) { return index; }
+function defaultGetItemKey(item, index) {
+  return index;
+}
 
 // Public: `VirtualList` is a React component that virtualizes the rendering of its item rows in
 // order to provide an efficient, high performing list view capable of handling a huge number of
@@ -71,11 +77,13 @@ class VirtualList extends React.Component {
       winSize: 10,
       viewportHeight: 1,
       avgRowHeight: 1,
-      scrollTop: 0
+      scrollTop: 0,
     };
 
     this.onScroll = this.onScroll.bind(this);
-    this.debouncedOnScroll = props.debounce ? debounce(this.debouncedOnScroll.bind(this), 30) : this.debouncedOnScroll;
+    this.debouncedOnScroll = props.debounce
+      ? debounce(this.debouncedOnScroll.bind(this), 30)
+      : this.debouncedOnScroll;
     this.checkForResize = this.checkForResize.bind(this);
   }
 
@@ -89,7 +97,10 @@ class VirtualList extends React.Component {
   // 3. Sample the just rendered row heights to get an average row height to use while handling
   //    scroll events.
   componentDidMount() {
-    this._resizeTimer = setInterval(this.checkForResize, this.props.resizeInterval);
+    this._resizeTimer = setInterval(
+      this.checkForResize,
+      this.props.resizeInterval,
+    );
     this.handleResize();
     this.sampleRowHeights();
   }
@@ -104,8 +115,8 @@ class VirtualList extends React.Component {
   //    average row height.
   componentDidUpdate() {
     const node = this.node;
-    const { childNodes } = this.content;
-    const { winSize, scrollTop } = this.state;
+    const {childNodes} = this.content;
+    const {winSize, scrollTop} = this.state;
 
     this.notifyFirstVisibleItemIfNecessary();
 
@@ -123,10 +134,12 @@ class VirtualList extends React.Component {
   }
 
   checkForResize() {
-    const { clientHeight } = this.node;
-    const { viewportHeight } = this.state;
+    const {clientHeight} = this.node;
+    const {viewportHeight} = this.state;
 
-    if (clientHeight !== viewportHeight) { this.handleResize(); }
+    if (clientHeight !== viewportHeight) {
+      this.handleResize();
+    }
   }
 
   // Internal: When the container node has been resized we need to adjust the internal
@@ -134,11 +147,15 @@ class VirtualList extends React.Component {
   // enough rows to fill the viewport.
   handleResize() {
     const node = this.node;
-    const { avgRowHeight } = this.state;
+    const {avgRowHeight} = this.state;
     const viewportHeight = node.clientHeight;
-    const winSize = Math.ceil(viewportHeight / avgRowHeight) + this.props.buffer;
-    if (viewportHeight !== this.state.viewportHeight || winSize !== this.state.winSize) {
-      this.setState({ viewportHeight, winSize });
+    const winSize =
+      Math.ceil(viewportHeight / avgRowHeight) + this.props.buffer;
+    if (
+      viewportHeight !== this.state.viewportHeight ||
+      winSize !== this.state.winSize
+    ) {
+      this.setState({viewportHeight, winSize});
     }
   }
 
@@ -152,32 +169,38 @@ class VirtualList extends React.Component {
         totalHeight += childNodes[i].offsetHeight;
       }
       const avgRowHeight = totalHeight / childNodes.length;
-      const winSize = Math.ceil(node.clientHeight / avgRowHeight) + this.props.buffer;
-      if (avgRowHeight !== this.state.avgRowHeight || winSize !== this.state.winSize) {
-        this.setState({ avgRowHeight, winSize });
+      const winSize =
+        Math.ceil(node.clientHeight / avgRowHeight) + this.props.buffer;
+      if (
+        avgRowHeight !== this.state.avgRowHeight ||
+        winSize !== this.state.winSize
+      ) {
+        this.setState({avgRowHeight, winSize});
       }
     }
   }
 
   notifyFirstVisibleItemIfNecessary() {
-    if (!this.props.onFirstVisibleItemChange) { return; }
+    if (!this.props.onFirstVisibleItemChange) {
+      return;
+    }
 
-    const first = this.findFirstVisibleItem();
+    const idx = this.findFirstVisibleItemIndex();
 
-    if (this._first !== first) {
-      this.props.onFirstVisibleItemChange(first);
-      this._first = first;
+    if (this._firstIndex !== idx) {
+      this.props.onFirstVisibleItemChange(this.props.items[idx], idx);
+      this._firstIndex = idx;
     }
   }
 
-  findFirstVisibleItem() {
+  findFirstVisibleItemIndex() {
     const childNodes = this.content.childNodes;
-    const { items } = this.props;
-    const { winStart, scrollTop } = this.state;
+    const {items} = this.props;
+    const {winStart, scrollTop} = this.state;
 
     for (let i = 0; i < childNodes.length; i++) {
-      if ((childNodes[i].offsetTop + childNodes[i].offsetHeight) >= scrollTop) {
-        return items[winStart + i];
+      if (childNodes[i].offsetTop + childNodes[i].offsetHeight >= scrollTop) {
+        return winStart + i;
       }
     }
 
@@ -186,53 +209,57 @@ class VirtualList extends React.Component {
 
   handleDownwardScroll(delta, callback) {
     const childNodes = this.content.childNodes;
-    const { items } = this.props;
-    const { winSize, avgRowHeight } = this.state;
+    const {items} = this.props;
+    const {winSize, avgRowHeight} = this.state;
     const maxWinStart = Math.max(0, items.length - winSize);
-    let { winStart, scrollTop } = this.state;
+    let {winStart, scrollTop} = this.state;
 
     scrollTop += delta;
 
     const startScrollTop = scrollTop;
 
     for (let i = 0; i < childNodes.length; i++) {
-      if (winStart < maxWinStart && childNodes[i].offsetTop + childNodes[i].offsetHeight < startScrollTop) {
+      if (
+        winStart < maxWinStart &&
+        childNodes[i].offsetTop + childNodes[i].offsetHeight < startScrollTop
+      ) {
         winStart++;
         scrollTop += avgRowHeight - childNodes[i].offsetHeight;
-      }
-      else {
+      } else {
         break;
       }
     }
 
     scrollTop = Math.round(scrollTop);
 
-    this.setState({ winStart, scrollTop }, callback);
+    this.setState({winStart, scrollTop}, callback);
   }
 
   handleUpwardScroll(delta, callback) {
     const node = this.node;
     const childNodes = this.content.childNodes;
-    let { winStart, scrollTop, avgRowHeight } = this.state;
+    let {winStart, scrollTop, avgRowHeight} = this.state;
     let n = 0;
 
     scrollTop += delta;
 
     for (let i = childNodes.length - 1; i >= 0; i--) {
-      if (winStart > 0 && (childNodes[i].offsetTop - scrollTop) > node.offsetHeight) {
+      if (
+        winStart > 0 &&
+        childNodes[i].offsetTop - scrollTop > node.offsetHeight
+      ) {
         winStart--;
         n++;
-      }
-      else {
+      } else {
         break;
       }
     }
 
-    this.setState({ winStart, scrollTop }, () => {
-      const { childNodes } = this.content;
+    this.setState({winStart, scrollTop}, () => {
+      const {childNodes} = this.content;
 
-      const { avgRowHeight } = this.state;
-      let { scrollTop } = this.state;
+      const {avgRowHeight} = this.state;
+      let {scrollTop} = this.state;
 
       for (let i = 0; i < n; i++) {
         scrollTop -= avgRowHeight - childNodes[i].offsetHeight;
@@ -240,31 +267,33 @@ class VirtualList extends React.Component {
 
       scrollTop = Math.round(scrollTop);
 
-      this.setState({ scrollTop }, callback);
+      this.setState({scrollTop}, callback);
     });
   }
 
   handleLongScroll(delta, callback) {
-    const { items } = this.props;
-    const { winSize, avgRowHeight } = this.state;
-    let { scrollTop } = this.state;
+    const {items} = this.props;
+    const {winSize, avgRowHeight} = this.state;
+    let {scrollTop} = this.state;
     const maxWinStart = Math.max(0, items.length - winSize);
     scrollTop += delta;
-    this.setState({
-      winStart: Math.min(maxWinStart, Math.floor(scrollTop / avgRowHeight)), scrollTop
-    }, callback);
+    this.setState(
+      {
+        winStart: Math.min(maxWinStart, Math.floor(scrollTop / avgRowHeight)),
+        scrollTop,
+      },
+      callback,
+    );
   }
 
   scroll(delta, callback) {
-    const { viewportHeight } = this.state;
+    const {viewportHeight} = this.state;
 
     if (Math.abs(delta) > viewportHeight) {
       this.handleLongScroll(delta, callback);
-    }
-    else if (delta > 0) {
+    } else if (delta > 0) {
       this.handleDownwardScroll(delta, callback);
-    }
-    else if (delta < 0) {
+    } else if (delta < 0) {
       this.handleUpwardScroll(delta, callback);
     }
 
@@ -272,13 +301,13 @@ class VirtualList extends React.Component {
   }
 
   scrollToIndex(index, callback) {
-    const { items } = this.props;
-    const { winSize, avgRowHeight } = this.state;
+    const {items} = this.props;
+    const {winSize, avgRowHeight} = this.state;
     const maxWinStart = Math.max(0, items.length - winSize);
     let winStart = Math.min(maxWinStart, index);
     let scrollTop = winStart * avgRowHeight;
 
-    this.setState({ winStart, scrollTop }, callback);
+    this.setState({winStart, scrollTop}, callback);
   }
 
   scrollToItem(item, callback) {
@@ -302,14 +331,13 @@ class VirtualList extends React.Component {
   //
   // Returns the receiver.
   itemsMutated(callback) {
-    const { items } = this.props;
-    const { winStart, winSize } = this.state;
+    const {items} = this.props;
+    const {winStart, winSize} = this.state;
     const maxWinStart = Math.max(0, items.length - winSize);
 
     if (winStart > maxWinStart) {
-      this.setState({ winStart: maxWinStart }, callback);
-    }
-    else {
+      this.setState({winStart: maxWinStart}, callback);
+    } else {
       this.forceUpdate(callback);
     }
 
@@ -326,7 +354,7 @@ class VirtualList extends React.Component {
 
   debouncedOnScroll(e) {
     const node = this.node;
-    const { scrollTop } = this.state;
+    const {scrollTop} = this.state;
 
     if (node.scrollTop !== scrollTop) {
       this.scroll(node.scrollTop - scrollTop);
@@ -335,21 +363,31 @@ class VirtualList extends React.Component {
   }
 
   render() {
-    const { items, getItem, getItemKey, scrollbarOffset } = this.props;
-    const { winStart, winSize, avgRowHeight } = this.state;
+    const {items, getItem, getItemKey, scrollbarOffset} = this.props;
+    const {winStart, winSize, avgRowHeight} = this.state;
     const winEnd = Math.min(items.length - 1, winStart + winSize - 1);
     const paddingTop = winStart * avgRowHeight;
-    const paddingBottom = Math.max((items.length - winStart - winSize) * avgRowHeight, 0);
-    const style = Object.assign({
-      position: 'absolute',
-      top: 0,
-      right: scrollbarOffset,
-      bottom: 0,
-      left: 0,
-      overflowY: 'auto',
-      overflowX: scrollbarOffset ? 'hidden' : undefined
-    }, this.props.style);
-    const contentStyle = { paddingTop, paddingBottom, marginRight: -scrollbarOffset };
+    const paddingBottom = Math.max(
+      (items.length - winStart - winSize) * avgRowHeight,
+      0,
+    );
+    const style = Object.assign(
+      {
+        position: 'absolute',
+        top: 0,
+        right: scrollbarOffset,
+        bottom: 0,
+        left: 0,
+        overflowY: 'auto',
+        overflowX: scrollbarOffset ? 'hidden' : undefined,
+      },
+      this.props.style,
+    );
+    const contentStyle = {
+      paddingTop,
+      paddingBottom,
+      marginRight: -scrollbarOffset,
+    };
     const itemView = React.Children.only(this.props.children);
     const itemNodes = [];
     let item;
@@ -357,13 +395,32 @@ class VirtualList extends React.Component {
     for (let i = winStart; i <= winEnd; i++) {
       item = getItem(items, i);
       itemNodes.push(
-        <Item key={getItemKey(item, i)} itemIndex={i} itemView={itemView} item={item} />
+        <Item
+          key={getItemKey(item, i)}
+          itemIndex={i}
+          itemView={itemView}
+          item={item}
+        />,
       );
     }
 
     return (
-      <div ref={(node) => { this.node = node; }} className="VirtualList" tabIndex="-1" style={style} onScroll={this.onScroll}>
-        <div ref={(content) => { this.content = content; }} className="VirtualList-content" style={contentStyle}>{itemNodes}</div>
+      <div
+        ref={node => {
+          this.node = node;
+        }}
+        className="VirtualList"
+        tabIndex="-1"
+        style={style}
+        onScroll={this.onScroll}>
+        <div
+          ref={content => {
+            this.content = content;
+          }}
+          className="VirtualList-content"
+          style={contentStyle}>
+          {itemNodes}
+        </div>
       </div>
     );
   }
@@ -407,7 +464,7 @@ VirtualList.propTypes = {
   style: PropTypes.object,
 
   // Specify whether to debounce onScroll handler
-  debounce: PropTypes.bool
+  debounce: PropTypes.bool,
 };
 
 VirtualList.defaultProps = {
@@ -416,7 +473,7 @@ VirtualList.defaultProps = {
   buffer: 4,
   scrollbarOffset: 0,
   resizeInterval: 1000,
-  debounce: false
+  debounce: false,
 };
 
 module.exports = VirtualList;


### PR DESCRIPTION
There is a bug with the `scrollToIndex` method when it is called immediately after the component first renders. The bug is due to the fact that row heights have not been sampled yet and thus an invalid value is computed for the `scrollTop` state variable. The fix is to simply detect this case and delay running the scroll logic until after the row heights have been sampled.